### PR TITLE
optional node build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Once you've created a project and installed dependencies with `npm install` (or 
 
 You can preview the production build with `npm run preview`.
 
+To build specifically for node (required for production deployment), use `npm run build-node`. This is as above, but first sets an env var (`SKADAPTER=node`) that controls the adapter used to build.
+
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@ons/design-system": "^45.2.2",
+        "@sveltejs/adapter-node": "^1.0.0-next.72",
         "d3-dsv": "^2.0.0",
+        "dotenv": "^16.0.0",
         "mapbox-gl": "^1.13.2",
         "normalize.css": "^8.0.1",
         "rxjs": "^7.5.4"
@@ -309,6 +311,14 @@
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "esbuild": "^0.14.21",
+        "tiny-glob": "^0.2.9"
+      }
+    },
+    "node_modules/@sveltejs/adapter-node": {
+      "version": "1.0.0-next.72",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.72.tgz",
+      "integrity": "sha512-+zlZM41LgluD6MI6NE2SgPe5Qee9KZfKyYu52+YAgORg+7OPfgwdOupLVlLk6wTyAbzq5lzpNMu5/qEfnCX++Q==",
+      "dependencies": {
         "tiny-glob": "^0.2.9"
       }
     },
@@ -1047,6 +1057,14 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/earcut": {
       "version": "2.2.3",
       "license": "ISC"
@@ -1588,7 +1606,9 @@
     "node_modules/globalyzer": {
       "version": "0.1.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
     },
     "node_modules/globby": {
       "version": "11.1.0",
@@ -1612,7 +1632,9 @@
     "node_modules/globrex": {
       "version": "0.1.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
@@ -2890,6 +2912,8 @@
       "version": "0.2.9",
       "dev": true,
       "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
       "dependencies": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
@@ -3274,6 +3298,14 @@
       "requires": {
         "@iarna/toml": "^2.2.5",
         "esbuild": "^0.14.21",
+        "tiny-glob": "^0.2.9"
+      }
+    },
+    "@sveltejs/adapter-node": {
+      "version": "1.0.0-next.72",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.72.tgz",
+      "integrity": "sha512-+zlZM41LgluD6MI6NE2SgPe5Qee9KZfKyYu52+YAgORg+7OPfgwdOupLVlLk6wTyAbzq5lzpNMu5/qEfnCX++Q==",
+      "requires": {
         "tiny-glob": "^0.2.9"
       }
     },
@@ -3684,6 +3716,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
+    },
     "earcut": {
       "version": "2.2.3"
     },
@@ -4027,7 +4064,9 @@
     },
     "globalyzer": {
       "version": "0.1.0",
-      "dev": true
+      "dev": true,
+      "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
     },
     "globby": {
       "version": "11.1.0",
@@ -4043,7 +4082,9 @@
     },
     "globrex": {
       "version": "0.1.2",
-      "dev": true
+      "dev": true,
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "graceful-fs": {
       "version": "4.2.9",
@@ -4774,6 +4815,8 @@
     "tiny-glob": {
       "version": "0.2.9",
       "dev": true,
+      "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
+      "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
       "requires": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,19 +11,20 @@
         "@ons/design-system": "^45.2.2",
         "@sveltejs/adapter-node": "^1.0.0-next.72",
         "d3-dsv": "^2.0.0",
-        "dotenv": "^16.0.0",
         "mapbox-gl": "^1.13.2",
         "normalize.css": "^8.0.1",
         "rxjs": "^7.5.4"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "next",
+        "@sveltejs/adapter-node": "^1.0.0-next.72",
         "@sveltejs/kit": "next",
         "@types/d3-dsv": "^3.0.0",
         "@types/mapbox-gl": "^2.6.1",
         "@typescript-eslint/eslint-plugin": "^5.10.1",
         "@typescript-eslint/parser": "^5.10.1",
         "autoprefixer": "^10.4.2",
+        "dotenv": "^16.0.0",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-svelte3": "^3.2.1",
@@ -318,6 +319,7 @@
       "version": "1.0.0-next.72",
       "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.72.tgz",
       "integrity": "sha512-+zlZM41LgluD6MI6NE2SgPe5Qee9KZfKyYu52+YAgORg+7OPfgwdOupLVlLk6wTyAbzq5lzpNMu5/qEfnCX++Q==",
+      "dev": true,
       "dependencies": {
         "tiny-glob": "^0.2.9"
       }
@@ -1061,6 +1063,7 @@
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
       "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -1605,10 +1608,10 @@
     },
     "node_modules/globalyzer": {
       "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
       "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/globby": {
       "version": "11.1.0",
@@ -1631,10 +1634,10 @@
     },
     "node_modules/globrex": {
       "version": "0.1.2",
-      "dev": true,
-      "license": "MIT",
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
@@ -2910,10 +2913,10 @@
     },
     "node_modules/tiny-glob": {
       "version": "0.2.9",
-      "dev": true,
-      "license": "MIT",
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
       "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
@@ -3305,6 +3308,7 @@
       "version": "1.0.0-next.72",
       "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-1.0.0-next.72.tgz",
       "integrity": "sha512-+zlZM41LgluD6MI6NE2SgPe5Qee9KZfKyYu52+YAgORg+7OPfgwdOupLVlLk6wTyAbzq5lzpNMu5/qEfnCX++Q==",
+      "dev": true,
       "requires": {
         "tiny-glob": "^0.2.9"
       }
@@ -3719,7 +3723,8 @@
     "dotenv": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.0.tgz",
-      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q=="
+      "integrity": "sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==",
+      "dev": true
     },
     "earcut": {
       "version": "2.2.3"
@@ -4064,9 +4069,9 @@
     },
     "globalyzer": {
       "version": "0.1.0",
-      "dev": true,
       "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
     },
     "globby": {
       "version": "11.1.0",
@@ -4082,9 +4087,9 @@
     },
     "globrex": {
       "version": "0.1.2",
-      "dev": true,
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.9",
@@ -4814,9 +4819,9 @@
     },
     "tiny-glob": {
       "version": "0.2.9",
-      "dev": true,
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
       "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
       "requires": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dev": "svelte-kit dev",
     "build": "svelte-kit build",
+    "build-node": "export SKADAPTER=node && svelte-kit build",
     "package": "svelte-kit package",
     "preview": "svelte-kit preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
@@ -36,7 +37,9 @@
   },
   "dependencies": {
     "@ons/design-system": "^45.2.2",
+    "@sveltejs/adapter-node": "^1.0.0-next.72",
     "d3-dsv": "^2.0.0",
+    "dotenv": "^16.0.0",
     "mapbox-gl": "^1.13.2",
     "rxjs": "^7.5.4",
     "normalize.css": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -15,19 +15,21 @@
   "type": "module",
   "devDependencies": {
     "@sveltejs/adapter-auto": "next",
+    "@sveltejs/adapter-node": "^1.0.0-next.72",
     "@sveltejs/kit": "next",
-    "sass": "^1.49.7",
     "@types/d3-dsv": "^3.0.0",
     "@types/mapbox-gl": "^2.6.1",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",
     "autoprefixer": "^10.4.2",
+    "dotenv": "^16.0.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-svelte3": "^3.2.1",
     "postcss": "^8.4.6",
     "prettier": "^2.5.1",
     "prettier-plugin-svelte": "^2.5.0",
+    "sass": "^1.49.7",
     "svelte": "^3.44.0",
     "svelte-check": "^2.2.6",
     "svelte-preprocess": "^4.10.1",
@@ -39,9 +41,8 @@
     "@ons/design-system": "^45.2.2",
     "@sveltejs/adapter-node": "^1.0.0-next.72",
     "d3-dsv": "^2.0.0",
-    "dotenv": "^16.0.0",
     "mapbox-gl": "^1.13.2",
-    "rxjs": "^7.5.4",
-    "normalize.css": "^8.0.1"
+    "normalize.css": "^8.0.1",
+    "rxjs": "^7.5.4"
   }
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,20 @@
 import adapter from "@sveltejs/adapter-auto";
+import dotenv from "dotenv";
+import nodeAdapter from "@sveltejs/adapter-node";
 import preprocess from "svelte-preprocess";
+
+dotenv.config();
+
+const getAdapter = () => {
+  const skAdapter = process.env.SKADAPTER;
+  if (skAdapter === "node") {
+    console.log("Building with node adapter.");
+    return nodeAdapter();
+  } else {
+    console.log("Building with automatic adapter.");
+    return adapter();
+  }
+};
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -11,7 +26,7 @@ const config = {
     },
   }),
   kit: {
-    adapter: adapter(),
+    adapter: getAdapter(),
   },
 };
 


### PR DESCRIPTION
### What

commit fa663fe4fec08bd007cda202e93ee210a22a5d3d (HEAD -> feature/build-node-and-netlify, origin/feature/build-node-and-netlify)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Mar 16 20:20:25 2022 +0000

    build with different adapters according to SKADAPTER env var

    - add switch to svelte.config.js that checks env for variable
    SKADAPTER.
    - if SKADAPTER='node', 'npm run build' will run with a node adapter
    - if SKADAPTER is anything else (or unset), 'npm run build' will
    run with automatic adapter
    - added npm build-node script that sets SKADAPTER='node' and then
    builds.

    These changes needed to allow env-specific builds (netlify for dev,
    node for prod).

### How to review

Make sure the netlify deploy worked ok - no home for node yet

### Who can review

anyone