### PR TITLE
Prettify and autofix everything

### DIFF
--- a/src/components/CategoryHeading.svelte
+++ b/src/components/CategoryHeading.svelte
@@ -1,31 +1,30 @@
 <script>
   import { areAllDefined } from "../util/genUtil";
   import { formatPercentage } from "../helpers/categoryHelper";
-  import { unCapitalizeFirstLetter } from "../util/stringUtil"
-  export let variableData
-  export let variable
-  export let category
+  import { unCapitalizeFirstLetter } from "../util/stringUtil";
+  export let variableData;
+  export let variable;
+  export let category;
   export let location;
-  
-  const percentPlaceholder = "00.0"
 
-  const formatCatHeadString = (variable, category, location, templateStr) => { 
+  const percentPlaceholder = "00.0";
+
+  const formatCatHeadString = (variable, category, location, templateStr) => {
     const stringReplaceMap = {
       "{category_name}": unCapitalizeFirstLetter(category.name),
       "{category_unit}": unCapitalizeFirstLetter(variable.units),
       "{location}": location,
       "{variable_name}": unCapitalizeFirstLetter(variable.name),
-    }
+    };
     for (const [strToReplace, replacementStr] of Object.entries(stringReplaceMap)) {
-      templateStr = templateStr.replace(strToReplace, replacementStr)
+      templateStr = templateStr.replace(strToReplace, replacementStr);
     }
-    return templateStr
-  }
+    return templateStr;
+  };
 
   const areArgsDefined = () => {
-    return areAllDefined([variableData, variable, category, location])
-  }
-
+    return areAllDefined([variableData, variable, category, location]);
+  };
 </script>
 
 <div>
@@ -42,7 +41,7 @@
     </div>
     <div>
       <span>
-        {areArgsDefined() ? formatCatHeadString(variable, category, location, category.category_h_pt3): ""}
+        {areArgsDefined() ? formatCatHeadString(variable, category, location, category.category_h_pt3) : ""}
       </span>
     </div>
   </div>

--- a/src/components/CategoryPage.svelte
+++ b/src/components/CategoryPage.svelte
@@ -31,12 +31,7 @@
   }
 </script>
 
-<CategoryHeading
-  variableData={variableData}
-  variable={variable}
-  category={category}
-  location={selectedGeographyDisplayName}
-/>
+<CategoryHeading {variableData} {variable} {category} location={selectedGeographyDisplayName} />
 
 <div class="tw-p-6 tw-bg-onspale tw-mb-6">
   <a class="tw-hyperlink" href={`/${search}`}>Home</a> <span class="tw-mx-1">&gt;</span>

--- a/src/components/TopicPage.svelte
+++ b/src/components/TopicPage.svelte
@@ -1,9 +1,8 @@
 <script lang="ts">
-
-  import { page } from '$app/stores';
+  import { page } from "$app/stores";
   import ONSAccordion from "./ons/ONSAccordion.svelte";
   import ONSAccordionPanel from "./ons/ONSAccordionPanel.svelte";
-  import topics from '../data/content'
+  import topics from "../data/content";
 
   $: url = $page.url;
   $: topicSlug = $page.params.topic;
@@ -27,20 +26,22 @@
       {topic.desc}
     </div>
     {#each topic.variables as variable}
-    <ONSAccordion showAll={false}>
-      <ONSAccordionPanel id={variable.slug} title={variable.name} description={variable.desc}>
-        <ul class="ons-list ons-list--bare">
-          {#each variable.categories as category}
-          <li class="ons-list__item">
-            <a class="ons-list__link"
-              href={`/2021/${topic.slug}/${variable.slug}/default/${category.slug}${url.search}`}>
-              {category.name}
-            </a>
-          </li>
-          {/each}
-        </ul>
-      </ONSAccordionPanel>
-    </ONSAccordion>
+      <ONSAccordion showAll={false}>
+        <ONSAccordionPanel id={variable.slug} title={variable.name} description={variable.desc}>
+          <ul class="ons-list ons-list--bare">
+            {#each variable.categories as category}
+              <li class="ons-list__item">
+                <a
+                  class="ons-list__link"
+                  href={`/2021/${topic.slug}/${variable.slug}/default/${category.slug}${url.search}`}
+                >
+                  {category.name}
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </ONSAccordionPanel>
+      </ONSAccordion>
     {/each}
   </main>
 </div>
@@ -48,7 +49,7 @@
 <style lang="scss">
   @import "../../node_modules/@ons/design-system/scss/vars/_index.scss";
 
-  a { 
+  a {
     text-decoration: underline;
   }
   a:visited {

--- a/src/components/ons/ONSAccordion.svelte
+++ b/src/components/ons/ONSAccordion.svelte
@@ -1,43 +1,42 @@
 <script>
-    import { onMount } from "svelte";
-  
-    onMount(async () => {
-      const collapsibleComponents = [...document.querySelectorAll(".ons-js-collapsible")];
-  
-      if (collapsibleComponents.length) {
-        const toggleAllButtons = [...document.querySelectorAll(".ons-js-collapsible-all")];
-  
-        const Collapsible = (
-          await import("./../../../node_modules/@ons/design-system/components/collapsible/collapsible")
+  import { onMount } from "svelte";
+
+  onMount(async () => {
+    const collapsibleComponents = [...document.querySelectorAll(".ons-js-collapsible")];
+
+    if (collapsibleComponents.length) {
+      const toggleAllButtons = [...document.querySelectorAll(".ons-js-collapsible-all")];
+
+      const Collapsible = (
+        await import("./../../../node_modules/@ons/design-system/components/collapsible/collapsible")
+      ).default;
+      const collapsibles = collapsibleComponents.map((element) => new Collapsible(element));
+
+      if (toggleAllButtons.length) {
+        const CollapsibleGroup = (
+          await import("./../../../node_modules/@ons/design-system/components/collapsible/collapsible.group")
         ).default;
-        const collapsibles = collapsibleComponents.map((element) => new Collapsible(element));
-  
-        if (toggleAllButtons.length) {
-          const CollapsibleGroup = (
-            await import("./../../../node_modules/@ons/design-system/components/collapsible/collapsible.group")
-          ).default;
-  
-          toggleAllButtons.forEach((button) => {
-            new CollapsibleGroup(button, collapsibles);
-          });
-        }
+
+        toggleAllButtons.forEach((button) => {
+          new CollapsibleGroup(button, collapsibles);
+        });
       }
-    });
-  
-    export let showAll = true;
-  </script>
-  
-  <div id="accordion" class="ons-accordion">
-    {#if showAll}
-      <button
-        type="button"
-        class="ons-btn ons-js-collapsible-all ons-u-mb-s ons-u-d-no ons-btn--secondary ons-btn--small"
-        data-close-all="Hide all"
-        data-group="accordion"
-      >
-        <span class="ons-btn__inner ons-js-collapsible-all-inner">Show all</span>
-      </button>
-    {/if}
-    <slot />
-  </div>
-  
+    }
+  });
+
+  export let showAll = true;
+</script>
+
+<div id="accordion" class="ons-accordion">
+  {#if showAll}
+    <button
+      type="button"
+      class="ons-btn ons-js-collapsible-all ons-u-mb-s ons-u-d-no ons-btn--secondary ons-btn--small"
+      data-close-all="Hide all"
+      data-group="accordion"
+    >
+      <span class="ons-btn__inner ons-js-collapsible-all-inner">Show all</span>
+    </button>
+  {/if}
+  <slot />
+</div>

--- a/src/components/ons/ONSAccordionPanel.svelte
+++ b/src/components/ons/ONSAccordionPanel.svelte
@@ -1,61 +1,60 @@
 <script>
-    export let id, title, description;
-    export let noTopBorder = false;
-  
-    let hasTopBorder = noTopBorder ? "ons-collapsible--noTopBorder" : "";
-  </script>
-  
-  <div
-    {id}
-    class="ons-collapsible ons-js-collapsible ons-collapsible--accordion {hasTopBorder}"
-    data-btn-close="Hide"
-    data-group="accordion"
-  >
-    <div class="ons-collapsible__heading ons-js-collapsible-heading">
-      <div class="ons-collapsible__controls">
-        <h2 class="ons-collapsible__title">{title}</h2>
-        <span class="ons-collapsible__icon">
-          <svg
-            class="ons-svg-icon "
-            viewBox="0 0 8 13"
-            xmlns="http://www.w3.org/2000/svg"
-            focusable="false"
-            fill="currentColor"
-          >
-            <path
-              d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
-              transform="translate(-5.02 -1.59)"
-            />
-          </svg>
-        </span>
-        <button
-          type="button"
-          class="ons-btn ons-collapsible__btn ons-js-collapsible-button ons-u-d-no ons-u-d-no@xxs@s ons-btn--secondary ons-btn--small"
+  export let id, title, description;
+  export let noTopBorder = false;
+
+  let hasTopBorder = noTopBorder ? "ons-collapsible--noTopBorder" : "";
+</script>
+
+<div
+  {id}
+  class="ons-collapsible ons-js-collapsible ons-collapsible--accordion {hasTopBorder}"
+  data-btn-close="Hide"
+  data-group="accordion"
+>
+  <div class="ons-collapsible__heading ons-js-collapsible-heading">
+    <div class="ons-collapsible__controls">
+      <h2 class="ons-collapsible__title">{title}</h2>
+      <span class="ons-collapsible__icon">
+        <svg
+          class="ons-svg-icon "
+          viewBox="0 0 8 13"
+          xmlns="http://www.w3.org/2000/svg"
+          focusable="false"
+          fill="currentColor"
         >
-          <span class="ons-btn__inner ons-js-collapsible-button-inner">Show</span>
-        </button>
-      </div>
-      {#if description}
-        <p class="ons-collapsible__title-description">
-          {description}
-        </p>
-      {/if}
+          <path
+            d="M5.74,14.28l-.57-.56a.5.5,0,0,1,0-.71h0l5-5-5-5a.5.5,0,0,1,0-.71h0l.57-.56a.5.5,0,0,1,.71,0h0l5.93,5.93a.5.5,0,0,1,0,.7L6.45,14.28a.5.5,0,0,1-.71,0Z"
+            transform="translate(-5.02 -1.59)"
+          />
+        </svg>
+      </span>
+      <button
+        type="button"
+        class="ons-btn ons-collapsible__btn ons-js-collapsible-button ons-u-d-no ons-u-d-no@xxs@s ons-btn--secondary ons-btn--small"
+      >
+        <span class="ons-btn__inner ons-js-collapsible-button-inner">Show</span>
+      </button>
     </div>
-    <div id="{id}-content" class="ons-collapsible__content ons-js-collapsible-content">
-      <slot />
-    </div>
+    {#if description}
+      <p class="ons-collapsible__title-description">
+        {description}
+      </p>
+    {/if}
   </div>
-  
-  <style lang="scss">
-    @import "../../node_modules/@ons/design-system/scss/vars/_index.scss";
-  
-    .ons-collapsible--noTopBorder:first-child .ons-collapsible__heading {
-      border-top: 0;
-    }
-  
-    .ons-collapsible__title-description {
-      color: #222;
-      margin: 0 9rem 0 0;
-    }
-  </style>
-  
+  <div id="{id}-content" class="ons-collapsible__content ons-js-collapsible-content">
+    <slot />
+  </div>
+</div>
+
+<style lang="scss">
+  @import "../../node_modules/@ons/design-system/scss/vars/_index.scss";
+
+  .ons-collapsible--noTopBorder:first-child .ons-collapsible__heading {
+    border-top: 0;
+  }
+
+  .ons-collapsible__title-description {
+    color: #222;
+    margin: 0 9rem 0 0;
+  }
+</style>

--- a/src/data/fetchGeographyData.ts
+++ b/src/data/fetchGeographyData.ts
@@ -4,8 +4,8 @@ import { selectedGeographyStore } from "../stores/stores";
 const apiBaseUrl = `https://cep5lmkia0.execute-api.eu-west-1.amazonaws.com/dev`;
 
 export const fetchGeographyData = async (args: { totalCode: string; categoryCodes: string[]; geoCode: string }) => {
-  let data = await fetchSelectedGeographyData(args);
-  let parsedData = parseSelectedGeographyData(data, args.totalCode);
+  const data = await fetchSelectedGeographyData(args);
+  const parsedData = parseSelectedGeographyData(data, args.totalCode);
   selectedGeographyStore.set({
     displayName: "England and Wales",
     geoCode: args.geoCode,

--- a/src/data/fetchVizData.ts
+++ b/src/data/fetchVizData.ts
@@ -13,7 +13,7 @@ export const fetchVizData = async (args: {
   geoType: GeoType;
   bbox: Bbox;
 }) => {
-  let [places, breaks] = await Promise.all([fetchQuery(args), fetchBreaks(args)]);
+  const [places, breaks] = await Promise.all([fetchQuery(args), fetchBreaks(args)]);
   vizStore.set({
     breaks: breaks[args.categoryCode].map((breakpoint) => parseFloat(breakpoint) * 100),
     places: places.map((row) => parsePlaceData(row, args.totalCode, args.categoryCode)),
@@ -23,30 +23,30 @@ export const fetchVizData = async (args: {
 };
 
 const fetchQuery = async (args: { totalCode: string; categoryCode: string; geoType: GeoType; bbox: Bbox }) => {
-  let bboxParam = getBboxString(args.bbox);
-  let url = `${apiBaseUrl}/query/2011?bbox=${bboxParam}&cols=geography_code,${args.totalCode},${args.categoryCode}&geotype=${args.geoType}`;
-  let response = await fetch(url);
-  let csv = await response.text();
+  const bboxParam = getBboxString(args.bbox);
+  const url = `${apiBaseUrl}/query/2011?bbox=${bboxParam}&cols=geography_code,${args.totalCode},${args.categoryCode}&geotype=${args.geoType}`;
+  const response = await fetch(url);
+  const csv = await response.text();
   return dsv.csvParse(csv);
 };
 
 const fetchBreaks = async (args: { totalCode: string; categoryCodes: string[]; geoType: GeoType }) => {
   const breakCount = 5;
 
-  let url = `${apiBaseUrl}/ckmeans/2011?divide_by=${args.totalCode}&cat=${args.categoryCodes.join(",")}&geotype=${
+  const url = `${apiBaseUrl}/ckmeans/2011?divide_by=${args.totalCode}&cat=${args.categoryCodes.join(",")}&geotype=${
     args.geoType
   }&k=${breakCount}`;
-  let response = await fetch(url);
-  let parsed = await response.json();
+  const response = await fetch(url);
+  const parsed = await response.json();
 
   // (ignore data from the API that we don't need)
   return Object.fromEntries(Object.keys(parsed).map((code) => [code, parsed[code][args.geoType.toUpperCase()]]));
 };
 
 const parsePlaceData = (row: dsv.DSVRowString<string>, totalCode: string, categoryCode: string) => {
-  let geoCode = row.geography_code;
-  let total = parseInt(row[totalCode]);
-  let count = parseInt(row[categoryCode]);
-  let percentage = (count / total) * 100;
+  const geoCode = row.geography_code;
+  const total = parseInt(row[totalCode]);
+  const count = parseInt(row[categoryCode]);
+  const percentage = (count / total) * 100;
   return { geoCode, count, total, percentage };
 };

--- a/src/helpers/categoryHelper.ts
+++ b/src/helpers/categoryHelper.ts
@@ -6,14 +6,14 @@ export const getCodesForCategory = (
   classificationSlug: string,
   categorySlug: string,
 ) => {
-  let topic = topics.find((t) => t.slug === topicSlug);
-  let variable = topic.variables.find((v) => v.slug === variableSlug);
-  let classification = {
+  const topic = topics.find((t) => t.slug === topicSlug);
+  const variable = topic.variables.find((v) => v.slug === variableSlug);
+  const classification = {
     name: "Default",
     desc: "Default classification",
     categories: variable.categories,
   };
-  let category = variable.categories.find((c) => c.slug === categorySlug);
+  const category = variable.categories.find((c) => c.slug === categorySlug);
 
   return {
     totalCode: variable.total.code,
@@ -23,11 +23,11 @@ export const getCodesForCategory = (
 };
 
 export const getCategoryInfo = (categoryCode: string) => {
-  let allVariables = topics.flatMap((t) => t.variables.map((v) => ({ topic: t, variable: v })));
-  let allCategories = allVariables.flatMap((v) =>
+  const allVariables = topics.flatMap((t) => t.variables.map((v) => ({ topic: t, variable: v })));
+  const allCategories = allVariables.flatMap((v) =>
     v.variable.categories.map((c) => ({ topic: v.topic, category: c, variable: v })),
   );
-  let match = allCategories.find((c) => c.category.code === categoryCode);
+  const match = allCategories.find((c) => c.category.code === categoryCode);
 
   return {
     topic: match.topic,

--- a/src/helpers/categoryHelper.ts
+++ b/src/helpers/categoryHelper.ts
@@ -49,5 +49,5 @@ export function getSelectedGeography(pageUrl) {
 }
 
 export const formatPercentage = (percentage: number) => {
-  return (Math.round(percentage * 10) / 10).toFixed(1)
-}
+  return (Math.round(percentage * 10) / 10).toFixed(1);
+};

--- a/src/helpers/queryParamsHelper.ts
+++ b/src/helpers/queryParamsHelper.ts
@@ -2,6 +2,6 @@ import { goto } from "$app/navigation";
 import type { GeoType } from "../types";
 
 export const setGeoSearchParam = (place: { geoType: GeoType; geoCode: string }) => {
-  let s = `?${place.geoType}=${place.geoCode}`;
+  const s = `?${place.geoType}=${place.geoCode}`;
   goto(s, { keepfocus: true, replaceState: false, noscroll: true });
 };

--- a/src/helpers/searchCensusHelper.ts
+++ b/src/helpers/searchCensusHelper.ts
@@ -1,19 +1,19 @@
 import topics from "../data/content";
 
 export const searchCensus = (q: string) => {
-  let s = q.toLowerCase();
+  const s = q.toLowerCase();
 
-  let topicResults = topics.filter((t) => t.name.toLowerCase().includes(s) || t.desc.toLowerCase().includes(s));
+  const topicResults = topics.filter((t) => t.name.toLowerCase().includes(s) || t.desc.toLowerCase().includes(s));
 
-  let allVariables = topics.flatMap((t) => t.variables.map((v) => ({ topic: t, variable: v })));
-  let variableResults = allVariables.filter(
+  const allVariables = topics.flatMap((t) => t.variables.map((v) => ({ topic: t, variable: v })));
+  const variableResults = allVariables.filter(
     (v) => v.variable.name.toLowerCase().includes(s) || v.variable.desc.toLowerCase().includes(s),
   );
 
-  let allCategories = allVariables.flatMap((v) =>
+  const allCategories = allVariables.flatMap((v) =>
     v.variable.categories.map((c) => ({ topic: v.topic, category: c, variable: v })),
   );
-  let categoryResults = allCategories.filter(
+  const categoryResults = allCategories.filter(
     (c) => c.category.name.toLowerCase().includes(s), // || c.desc.toLowerCase().includes(s)
   );
 

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -11,7 +11,7 @@ mapboxgl.accessToken = "pk.eyJ1Ijoic3Vtb3RoZWNhdCIsImEiOiJjaWxocngyanYwMDY4dmprc
 
 /** Configure the map's properties and subscribe to its events. */
 export const initMap = (container) => {
-  let map = new Map({
+  const map = new Map({
     container,
     style: "mapbox://styles/mapbox/navigation-day-v1",
     center: { lat: 53, lng: -2 },
@@ -42,7 +42,7 @@ export const initMap = (container) => {
     });
 
   map.on("click", "msoa-features", (e) => {
-    let geoCode = e.features[0].properties["areacd"];
+    const geoCode = e.features[0].properties["areacd"];
     setGeoSearchParam({ geoType: "msoa", geoCode });
   });
 
@@ -50,9 +50,9 @@ export const initMap = (container) => {
 };
 
 const setMapStore = (map: mapboxgl.Map) => {
-  let b = map.getBounds();
-  let bbox = { east: b.getEast(), north: b.getNorth(), west: b.getWest(), south: b.getSouth() };
-  let zoom = map.getZoom();
+  const b = map.getBounds();
+  const bbox = { east: b.getEast(), north: b.getNorth(), west: b.getWest(), south: b.getSouth() };
+  const zoom = map.getZoom();
 
   mapStore.set({
     bbox,

--- a/src/map/renderMapViz.ts
+++ b/src/map/renderMapViz.ts
@@ -5,10 +5,10 @@ export const renderMapViz = (map: mapboxgl.Map, data: VizData) => {
   if (!data) return;
 
   // @ts-ignore (typings for this overload are currently missing)
-  let features = map.queryRenderedFeatures({ layers: ["msoa-features"] });
+  const features = map.queryRenderedFeatures({ layers: ["msoa-features"] });
 
   features.forEach((f) => {
-    let dataForFeature = data.places.find((p) => p.geoCode === f.id);
+    const dataForFeature = data.places.find((p) => p.geoCode === f.id);
 
     if (dataForFeature) {
       map.setFeatureState(
@@ -20,7 +20,7 @@ export const renderMapViz = (map: mapboxgl.Map, data: VizData) => {
 };
 
 const getChoroplethColour = (value: number, breaks: number[]) => {
-  for (let b of breaks.map((b, i) => ({ breakpoint: b, colour: choroplethColours[i] }))) {
+  for (const b of breaks.map((b, i) => ({ breakpoint: b, colour: choroplethColours[i] }))) {
     if (value <= b.breakpoint) return b.colour;
   }
 };

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -23,7 +23,6 @@
   @import "./../../node_modules/@ons/design-system/components/button/button";
   @import "./../../node_modules/@ons/design-system/components/icons/icons";
 
-
   @import "./../../node_modules/@ons/design-system/scss/utilities/index";
   // Right to left
   @import "./../../node_modules/@ons/design-system/scss/overrides/rtl";

--- a/src/util/genUtil.ts
+++ b/src/util/genUtil.ts
@@ -1,3 +1,3 @@
-export const areAllDefined = (argAry: Array<Object | String | number>) => {
+export const areAllDefined = (argAry: Array<Object | string | number>) => {
   return argAry.filter((arg) => arg === undefined).length === 0;
 };

--- a/src/util/genUtil.ts
+++ b/src/util/genUtil.ts
@@ -1,3 +1,3 @@
-export const areAllDefined = (argAry: Array<Object|String|number>) => {
-    return argAry.filter((arg) => arg === undefined).length === 0
-}
+export const areAllDefined = (argAry: Array<Object | String | number>) => {
+  return argAry.filter((arg) => arg === undefined).length === 0;
+};

--- a/src/util/numberUtil.ts
+++ b/src/util/numberUtil.ts
@@ -1,9 +1,9 @@
 import { capitalizeFirstLetter } from "./stringUtil";
 
 var num =
-"zero one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen".split(
-  " ",
-);
+  "zero one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen".split(
+    " ",
+  );
 var tens = "twenty thirty forty fifty sixty seventy eighty ninety".split(" ");
 
 // https://stackoverflow.com/a/38658925

--- a/src/util/numberUtil.ts
+++ b/src/util/numberUtil.ts
@@ -1,15 +1,15 @@
 import { capitalizeFirstLetter } from "./stringUtil";
 
-var num =
+const num =
   "zero one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen".split(
     " ",
   );
-var tens = "twenty thirty forty fifty sixty seventy eighty ninety".split(" ");
+const tens = "twenty thirty forty fifty sixty seventy eighty ninety".split(" ");
 
 // https://stackoverflow.com/a/38658925
 function number2words(n) {
   if (n < 20) return num[n];
-  var digit = n % 10;
+  const digit = n % 10;
   if (n < 100) return tens[~~(n / 10) - 2] + (digit ? "-" + num[digit] : "");
   if (n < 1000) return num[~~(n / 100)] + " hundred" + (n % 100 == 0 ? "" : " " + number2words(n % 100));
   return number2words(~~(n / 1000)) + " thousand" + (n % 1000 != 0 ? " " + number2words(n % 1000) : "");

--- a/src/util/stringUtil.ts
+++ b/src/util/stringUtil.ts
@@ -1,7 +1,7 @@
 export function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
+  return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
 export function unCapitalizeFirstLetter(string) {
-    return string.charAt(0).toLowerCase() + string.slice(1);
+  return string.charAt(0).toLowerCase() + string.slice(1);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
-	"compilerOptions": {
-		"moduleResolution": "node",
-		"module": "es2020",
-		"lib": ["es2020", "DOM", "DOM.Iterable"],
-		"target": "es2020",
-		/**
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "es2020",
+    "lib": ["es2020", "DOM", "DOM.Iterable"],
+    "target": "es2020",
+    /**
 			svelte-preprocess cannot figure out whether you have a value or a type, so tell TypeScript
 			to enforce using \`import type\` instead of \`import\` for Types.
 		*/


### PR DESCRIPTION
This is a follow up from #13 to avoid formatting each other's code now that Prettier formatting and ESLint's `--fix` are run on each save in VSCode. As per my [previous comment](https://github.com/ONSdigital/dp-census-atlas/pull/13#issue-1175739747), if anything gets in a way we should consider changing the rules to suit us. The defaults are pretty sane though.

Note ESLint still shows some errors (40 errors, 4 warnings) but these aren't autofixable.