### PR TITLE
Stop asking geo endpoint for england and wales data (not available)

### DIFF
--- a/src/data/fetchGeographyData.ts
+++ b/src/data/fetchGeographyData.ts
@@ -31,7 +31,7 @@ export const fetchGeographyData = async (args: { totalCode: string; categoryCode
 
 export const fetchGeographyLookup = async (location: string, useCode = true) => {
   // return defaultGeography if the name or code matches...
-  if ((useCode && defaultGeography.meta.code == location) || defaultGeography.meta.code == location) {
+  if ((useCode && defaultGeography.meta.code == location) || defaultGeography.meta.name == location) {
     return JSON.stringify(defaultGeography);
   }
   // otherwise query API

--- a/src/data/fetchGeographyData.ts
+++ b/src/data/fetchGeographyData.ts
@@ -1,6 +1,7 @@
 import * as dsv from "d3-dsv"; // https://github.com/d3/d3/issues/3469
 import { selectedGeographyStore } from "../stores/stores";
 import type { GeographyLookupProps } from "../types";
+import { defaultGeography } from "../helpers/spatialHelper";
 
 const apiBaseUrl = `https://cep5lmkia0.execute-api.eu-west-1.amazonaws.com/dev`;
 
@@ -29,6 +30,11 @@ export const fetchGeographyData = async (args: { totalCode: string; categoryCode
 };
 
 export const fetchGeographyLookup = async (location: string, useCode = true) => {
+  // return defaultGeography if the name or code matches...
+  if ((useCode && defaultGeography.meta.code == location) || defaultGeography.meta.code == location) {
+    return JSON.stringify(defaultGeography);
+  }
+  // otherwise query API
   const url = `${apiBaseUrl}/geo/2011?${useCode ? "geocode" : "geoname"}=${location}`;
   const response = await fetch(url);
   const data = await response.text();

--- a/src/data/fetchGeographyData.ts
+++ b/src/data/fetchGeographyData.ts
@@ -15,7 +15,7 @@ export const fetchGeographyData = async (args: { totalCode: string; categoryCode
       meta: { name, geotype },
     }: GeographyLookupProps = JSON.parse(response);
     displayName = name;
-    geoType = geoType;
+    geoType = geoType.toLowerCase();
   });
 
   /* TODO: Grab geoType from endpoint */

--- a/src/helpers/categoryHelpers.ts
+++ b/src/helpers/categoryHelpers.ts
@@ -1,4 +1,5 @@
 import topics from "../data/content";
+import { defaultGeography } from "./spatialHelper";
 
 export const getCodesForCategory = (
   topicSlug: string,
@@ -44,7 +45,7 @@ export function getSelectedGeography(pageUrl) {
   if (geoCode) {
     return { geoType, geoCode };
   } else {
-    return { geoType: "ew", geoCode: "K04000001" };
+    return { geoType: defaultGeography.meta.geotype.toLowerCase(), geoCode: defaultGeography.meta.code };
   }
 }
 

--- a/src/helpers/categoryHelpers.ts
+++ b/src/helpers/categoryHelpers.ts
@@ -45,7 +45,7 @@ export function getSelectedGeography(pageUrl) {
   if (geoCode) {
     return { geoType, geoCode };
   } else {
-    return { geoType: defaultGeography.meta.geotype.toLowerCase(), geoCode: defaultGeography.meta.code };
+    return { geoType: defaultGeography.meta.geotype, geoCode: defaultGeography.meta.code };
   }
 }
 

--- a/src/helpers/spatialHelper.ts
+++ b/src/helpers/spatialHelper.ts
@@ -8,7 +8,7 @@ export const defaultGeography: GeographyLookupProps = {
   meta: {
     name: "England and Wales",
     code: "K04000001",
-    geotype: "EW",
+    geotype: "ew",
   },
   geo_json: {
     type: "FeatureCollection",

--- a/src/helpers/spatialHelper.ts
+++ b/src/helpers/spatialHelper.ts
@@ -1,5 +1,17 @@
-import type { Bbox } from "../types";
+import type { Bbox, GeographyLookupProps } from "../types";
 
 export const getBboxString = (args: Bbox) => {
   return [args.east, args.north, args.west, args.south].map((n) => n.toFixed(6)).join(",");
+};
+
+export const defaultGeography: GeographyLookupProps = {
+  meta: {
+    name: "England and Wales",
+    code: "K04000001",
+    geotype: "EW",
+  },
+  geo_json: {
+    type: "FeatureCollection",
+    features: [],
+  },
 };


### PR DESCRIPTION
### What

commit 195a67f98de9cad7b05c680d857870a252e4fba2 (HEAD -> fix/category-heading-no-category-data, origin/fix/category-heading-no-category-data)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Mar 23 16:02:35 2022 +0000

    Stop asking geo endpoint for england and wales data (not available)

    Refactor fetchGeographyData.fetchGeographyLookup to return
    spatialHelper.defaultGeography (England and Wales) if asked for
    something that matches, RATHER than ask the API for it.

    This change needed as the back end does not hold geometry data for
    England and Wales.

Describe what you have changed and why.

### How to review

Read the code etc, check preview can handle having England and Wales in the selected geography store

### Who can review

Anyone