### PR TITLE
/heath endpoint for ONS CI heartbeat monitoring

### DIFF
--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -1,0 +1,11 @@
+import type { RequestHandler } from "@sveltejs/kit";
+
+// simple healthcheck endpoint for use by ONS CI as heartbeat
+export const get: RequestHandler = async ({ params }) => {
+  return {
+    status: 200,
+    body: {
+      status: "OK",
+    },
+  };
+};


### PR DESCRIPTION
### What

Add simple /health endpoint returning 200 + basic JSON. This
change needed to allow ONS CI (nomad) to monitor deployment
health.

### How to review

run app and chec the /health route

### Who can review

Anyone