### PR TITLE
use correct app start args for nomad

### DIFF
--- a/dp-census-atlas.nomad
+++ b/dp-census-atlas.nomad
@@ -36,7 +36,7 @@ job "dp-census-atlas" {
       config {
         command = "${NOMAD_TASK_DIR}/start-task"
 
-        args = ["./dp-census-atlas"]
+        args = ["node",  "build/index.js"]
 
         image = "{{ECR_URL}}:concourse-{{REVISION}}"
 


### PR DESCRIPTION
nomad file was using default go-binary-starting command (./dp-census-atlas) but this is a node project, so needs a node start command.
