### PR TITLE
add text/javascript mime type to all scripts

### DIFF
--- a/src/components/Button.svelte
+++ b/src/components/Button.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import Icon from "./Icon.svelte";
   import type { IconType } from "./Icon.svelte";
 

--- a/src/components/CategoryHeading.svelte
+++ b/src/components/CategoryHeading.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { areAllDefined } from "../util/genUtil";
   import { formatPercentage, formatTemplateString } from "../helpers/categoryHelpers";
   import { choroplethColours } from "../helpers/choroplethHelpers";

--- a/src/components/CategoryLocationSummary.svelte
+++ b/src/components/CategoryLocationSummary.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { areAllDefined } from "../util/genUtil";
   import { formatTemplateString, formatPercentage } from "../helpers/categoryHelpers";
   import { englandAndWales } from "../helpers/spatialHelper";

--- a/src/components/CategoryPage.svelte
+++ b/src/components/CategoryPage.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { _ } from "svelte-i18n";
   import { page } from "$app/stores";
 

--- a/src/components/CensusPanel.svelte
+++ b/src/components/CensusPanel.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { page } from "$app/stores";
   import { _, json } from "svelte-i18n";
 

--- a/src/components/CensusTable.svelte
+++ b/src/components/CensusTable.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import { page } from "$app/stores";
   import { buildHyperlink } from "../helpers/buildHyperlinkHelper";
   export let variableData, variable;

--- a/src/components/Explore.svelte
+++ b/src/components/Explore.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { _ } from "svelte-i18n";
 
   export let content: { label: string; href: string; onClick?: () => void }[];

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { _, json } from "svelte-i18n";
   const links: { label: string; href: string }[] = $json("footer.links");
 </script>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import { buildHyperlink } from "../helpers/buildHyperlinkHelper";
   import { page } from "$app/stores";
   import Icon from "./Icon.svelte";

--- a/src/components/Heading.svelte
+++ b/src/components/Heading.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   export let serviceTitle: string;
   export let description: string = "";
 </script>

--- a/src/components/HomePage.svelte
+++ b/src/components/HomePage.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import { _ } from "svelte-i18n";
   import CensusPanel from "./CensusPanel.svelte";
   import Heading from "./Heading.svelte";

--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script type="text/javascript" context="module" lang="ts">
   export type IconType =
     | "facebook"
     | "twitter"
@@ -11,7 +11,7 @@
     | "info";
 </script>
 
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import Facebook from "./icons/Facebook.svelte";
   import Twitter from "./icons/Twitter.svelte";
   import Linkedin from "./icons/Linkedin.svelte";

--- a/src/components/Layout.svelte
+++ b/src/components/Layout.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import Header from "./Header.svelte";
   import Footer from "./Footer.svelte";
   import Map from "./Map.svelte";

--- a/src/components/LocationOverview.svelte
+++ b/src/components/LocationOverview.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { _, json } from "svelte-i18n";
   import { page } from "$app/stores";
   import { selectedGeographyStore } from "../stores/stores";

--- a/src/components/LocationPage.svelte
+++ b/src/components/LocationPage.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
 

--- a/src/components/Map.svelte
+++ b/src/components/Map.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { onMount, onDestroy } from "svelte";
   import { initMap } from "../map/initMap";
 

--- a/src/components/MapKey.svelte
+++ b/src/components/MapKey.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { _ } from "svelte-i18n";
   import { vizStore } from "../stores/stores";
   import { choroplethColours } from "../helpers/choroplethHelpers";

--- a/src/components/NavigationComponent.svelte
+++ b/src/components/NavigationComponent.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import { buildHyperlink } from "../helpers/buildHyperlinkHelper";
   import { page } from "$app/stores";
 

--- a/src/components/RadioButton.svelte
+++ b/src/components/RadioButton.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   export let selected = false;
 </script>
 

--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import ONSAutoSuggest from "./ons/ONSAutoSuggest.svelte";
   import ONSError from "./ons/ONSError.svelte";
 

--- a/src/components/SearchHeader.svelte
+++ b/src/components/SearchHeader.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { _ } from "svelte-i18n";
   import { selectedGeographyStore } from "../stores/stores";
 

--- a/src/components/TopicList.svelte
+++ b/src/components/TopicList.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import ONSCard from "./ons/ONSCard.svelte";
   import topics from "../data/content";
   import { buildHyperlink } from "../helpers/buildHyperlinkHelper";

--- a/src/components/TopicPage.svelte
+++ b/src/components/TopicPage.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
 

--- a/src/components/TopicsPage.svelte
+++ b/src/components/TopicsPage.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { page } from "$app/stores";
   import { _ } from "svelte-i18n";
 

--- a/src/components/VariablePage.svelte
+++ b/src/components/VariablePage.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { page } from "$app/stores";
   import { numberToWords } from "../util/numberUtil";
   import RightChevron from "./RightChevron.svelte";

--- a/src/components/ons/ONSAccordion.svelte
+++ b/src/components/ons/ONSAccordion.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import { onMount } from "svelte";
 
   onMount(async () => {

--- a/src/components/ons/ONSAccordionPanel.svelte
+++ b/src/components/ons/ONSAccordionPanel.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   export let id, title, description;
   export let noTopBorder = false;
 

--- a/src/components/ons/ONSAutoSuggest.svelte
+++ b/src/components/ons/ONSAutoSuggest.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import { onMount } from "svelte";
   export let labelText, id, autosuggestValue, autosuggestMeta, autosuggestData, header, invertTextColor, renderError;
   let n;

--- a/src/components/ons/ONSCard.svelte
+++ b/src/components/ons/ONSCard.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   export let href: string, title: string, id: string;
 </script>
 

--- a/src/components/ons/ONSCollapsible.svelte
+++ b/src/components/ons/ONSCollapsible.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import { onMount } from "svelte";
 
   onMount(async () => {

--- a/src/components/ons/ONSError.svelte
+++ b/src/components/ons/ONSError.svelte
@@ -1,19 +1,18 @@
-<script>
-    export let errorText, id;
-    export let renderError = false;
-  </script>
-  
-  {#if renderError}
-    <div class="ons-panel ons-panel--error ons-panel--no-title ons-u-mb-s" id="{id}-error">
-      <span class="ons-u-vh">Error: </span>
-      <div class="ons-panel__body">
-        <p class="ons-panel__error">
-          <strong>{errorText}</strong>
-        </p>
-        <slot />
-      </div>
+<script type="text/javascript">
+  export let errorText, id;
+  export let renderError = false;
+</script>
+
+{#if renderError}
+  <div class="ons-panel ons-panel--error ons-panel--no-title ons-u-mb-s" id="{id}-error">
+    <span class="ons-u-vh">Error: </span>
+    <div class="ons-panel__body">
+      <p class="ons-panel__error">
+        <strong>{errorText}</strong>
+      </p>
+      <slot />
     </div>
-  {:else}
-    <slot />
-  {/if}
-  
+  </div>
+{:else}
+  <slot />
+{/if}

--- a/src/components/ons/ONSShare.svelte
+++ b/src/components/ons/ONSShare.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   export let title = "Share this post";
 </script>
 

--- a/src/components/ons/ONSShareItem.svelte
+++ b/src/components/ons/ONSShareItem.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import { page } from "$app/stores";
   export let title: string = "";
   export let label: string;

--- a/src/routes/2021/[topic].svelte
+++ b/src/routes/2021/[topic].svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import TopicPage from "../../components/TopicPage.svelte";
 </script>
 

--- a/src/routes/2021/[topic]/[variable].svelte
+++ b/src/routes/2021/[topic]/[variable].svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import VariablePage from "../../../components/VariablePage.svelte";
 </script>
 

--- a/src/routes/2021/[topic]/[variable]/[classification]/[category].svelte
+++ b/src/routes/2021/[topic]/[variable]/[classification]/[category].svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import CategoryPage from "../../../../../components/CategoryPage.svelte";
 </script>
 

--- a/src/routes/2021/location.svelte
+++ b/src/routes/2021/location.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import LocationPage from "../../components/LocationPage.svelte";
 </script>
 

--- a/src/routes/2021/topics.svelte
+++ b/src/routes/2021/topics.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script type="text/javascript" lang="ts">
   import TopicsPage from "../../components/TopicsPage.svelte";
 </script>
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import "mapbox-gl/dist/mapbox-gl.css";
   import "../app.css";
   import "../components/ons/vars.css";

--- a/src/routes/census-atlas.svelte
+++ b/src/routes/census-atlas.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import HomePage from "../components/HomePage.svelte";
 </script>
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script type="text/javascript">
   import HomePage from "../components/HomePage.svelte";
 </script>
 


### PR DESCRIPTION
### What
 add text/javascript mime type to all scripts - this is intended to fix errors found on https://develop.onsdigital.co.uk/census-atlas:
 ```
Failed to load module script: Expected a JavaScript module script but the server responded with a MIME type of "". Strict MIME type checking is enforced for module scripts per HTML spec.
 ```
### How to review

check the preview isn't broken, check the tags are well-formed etc

### Who can review

Anyone