### PR TITLE
Feature/snap bbox requests to slippy map x,y

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "svelteapp",
       "version": "0.0.1",
       "dependencies": {
+        "@mapbox/tilebelt": "^1.0.2",
         "@ons/design-system": "^45.2.2",
         "d3-dsv": "^2.0.0",
         "fuse.js": "^3.6.1",
@@ -1154,6 +1155,11 @@
     "node_modules/@mapbox/point-geometry": {
       "version": "0.1.0",
       "license": "ISC"
+    },
+    "node_modules/@mapbox/tilebelt": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/tilebelt/-/tilebelt-1.0.2.tgz",
+      "integrity": "sha512-tGJN2VIgWrXqBTPIxFVklklIpcy6ss8W5ouq+cjNLXPXFraRaDR4Ice+5Q8/uLX+6aH23lWBMydOIn8PcdVcpA=="
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "1.2.5",
@@ -8125,6 +8131,11 @@
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0"
+    },
+    "@mapbox/tilebelt": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/tilebelt/-/tilebelt-1.0.2.tgz",
+      "integrity": "sha512-tGJN2VIgWrXqBTPIxFVklklIpcy6ss8W5ouq+cjNLXPXFraRaDR4Ice+5Q8/uLX+6aH23lWBMydOIn8PcdVcpA=="
     },
     "@mapbox/tiny-sdf": {
       "version": "1.2.5"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "typescript": "~4.5.4"
   },
   "dependencies": {
+    "@mapbox/tilebelt": "^1.0.2",
     "@ons/design-system": "^45.2.2",
     "d3-dsv": "^2.0.0",
     "fuse.js": "^3.6.1",

--- a/src/components/CategoryPage.svelte
+++ b/src/components/CategoryPage.svelte
@@ -44,6 +44,7 @@
         geoType: $mapStore.geoType, // todo remove
         geoCode: selectedGeographyGeoCode,
         bbox: $mapStore.bbox,
+        zoom: $mapStore.zoom,
       });
       setSelectedGeographyVariableStore({
         totalCode: codes.totalCode,

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,12 +1,18 @@
 import * as dsv from "d3-dsv"; // https://github.com/d3/d3/issues/3469
 import type { Bbox, GeoType } from "src/types";
-import { englandAndWales, getBboxString } from "../helpers/spatialHelper";
+import { englandAndWales, getBboxString, getQuantisedBbox } from "../helpers/spatialHelper";
 
 export const apiBaseUrl =
   import.meta.env.VITE_API_BASE_URL || "https://cep5lmkia0.execute-api.eu-west-1.amazonaws.com/dev";
 
-export const fetchQuery = async (args: { totalCode: string; categoryCode: string; geoType: GeoType; bbox: Bbox }) => {
-  const bboxParam = getBboxString(args.bbox);
+export const fetchQuery = async (args: {
+  totalCode: string;
+  categoryCode: string;
+  geoType: GeoType;
+  bbox: Bbox;
+  zoom: number;
+}) => {
+  const bboxParam = getBboxString(getQuantisedBbox(args.bbox, args.zoom));
   const url = `${apiBaseUrl}/query/2011?bbox=${bboxParam}&cols=geography_code,${args.totalCode},${args.categoryCode}&geotype=${args.geoType}`;
   const response = await fetch(url);
   const csv = await response.text();
@@ -20,7 +26,7 @@ export const fetchBreaks = async (args: {
 }): Promise<{ breaks: { [categoryCode: string]: number[] }; minMax: { [categoryCode: string]: number[] } }> => {
   const breakCount = 5;
 
-  // TODO imporove this? or don't get here if England & Wales
+  // TODO improve this? or don't get here if England & Wales
   // return -1s (so that all data will NOT be assigned a break, and the map will remain colorless) if its the default
   // geography (england and wales)
   if (args.geoType === englandAndWales.meta.geotype) {

--- a/src/data/setVizStore.ts
+++ b/src/data/setVizStore.ts
@@ -11,6 +11,7 @@ export const setVizStore = async (args: {
   geoType: GeoType;
   geoCode: string;
   bbox: Bbox;
+  zoom: number;
 }) => {
   const [places, breaksData] = await Promise.all([fetchQuery(args), fetchBreaks(args)]);
   vizStore.set({

--- a/src/helpers/spatialHelper.ts
+++ b/src/helpers/spatialHelper.ts
@@ -1,3 +1,4 @@
+import { pointToTile, tileToBBOX } from "@mapbox/tilebelt";
 import type { Bbox, GeographyInfo } from "../types";
 
 export const getBboxString = (args: Bbox) => {
@@ -20,4 +21,46 @@ export const englandAndWales: GeographyInfo = {
       },
     ],
   },
+};
+
+// uk bounding box, taken from UK bbox value used in API
+// https://github.com/ONSdigital/dp-geodata-api/blob/develop/pkg/geodata/coords.go
+export const UKBbox: Bbox = {
+  east: 1.76,
+  north: 58.64,
+  west: -7.57,
+  south: 49.92,
+};
+
+// maxmium zoom level at which to subsitute UKBbox for arbitrary viewport bbox
+export const MaxZoomToUseUKBbox = 6;
+
+/*
+  Snap viewport bounding box coordinates to closest slippy map tile integer X,Y values for current zoom (see
+  https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) to make bounding box requests cachable.
+*/
+export const getQuantisedBbox = (bbox: Bbox, zoom: number) => {
+  // round down zoom level to ensure snap is to integer tile grid
+  const floorZoom = Math.floor(zoom);
+
+  // if zoom is lower than minZoomToSnapBBoxes, just return bbox for all of UK
+  if (floorZoom <= MaxZoomToUseUKBbox) {
+    return UKBbox;
+  }
+
+  // get map tiles for current zoom that contain bbox corners
+  const neTile = pointToTile(bbox.east, bbox.north, floorZoom);
+  const swTile = pointToTile(bbox.west, bbox.south, floorZoom);
+
+  // convert map tiles to bboxes
+  const neTileBbox = tileToBBOX(neTile);
+  const swTileBbox = tileToBBOX(swTile);
+
+  // return bbox for both tiles  (NB tilebelt/mapbox uses West, South, East, North bbox convention)
+  return {
+    east: neTileBbox[2],
+    north: neTileBbox[3],
+    west: swTileBbox[0],
+    south: swTileBbox[1],
+  };
 };

--- a/src/helpers/spatialHelper.ts.test.ts
+++ b/src/helpers/spatialHelper.ts.test.ts
@@ -1,0 +1,32 @@
+import { getQuantisedBbox, MaxZoomToUseUKBbox, UKBbox } from "./spatialHelper";
+import tilebelt from "@mapbox/tilebelt";
+
+const testBbox = {
+  east: 1,
+  north: 50,
+  west: -1,
+  south: 48,
+};
+
+describe("getQuantisedBbox", () => {
+  test("returns UK bbox for zoom levels below MaxZoomToUseUKBbox", () => {
+    const zoom = MaxZoomToUseUKBbox * 0.8;
+    expect(getQuantisedBbox(testBbox, zoom)).toEqual(UKBbox);
+  });
+  test("returns UK bbox for zoom levels at MaxZoomToUseUKBbox", () => {
+    const zoom = MaxZoomToUseUKBbox;
+    expect(getQuantisedBbox(testBbox, zoom)).toEqual(UKBbox);
+  });
+  test("returns bbox based on slippy map tile X,Y grid for zoom levels above MaxZoomToUseUKBbox", () => {
+    const zoom = MaxZoomToUseUKBbox * 2;
+    const mockTileBeltBBox = [1, 2, 3, 4];
+    jest.spyOn(tilebelt, "tileToBBOX").mockReturnValue(mockTileBeltBBox);
+    const expectedBbox = {
+      east: mockTileBeltBBox[2],
+      north: mockTileBeltBBox[3],
+      west: mockTileBeltBBox[0],
+      south: mockTileBeltBBox[1],
+    };
+    expect(getQuantisedBbox(testBbox, zoom)).toEqual(expectedBbox);
+  });
+});

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -78,6 +78,7 @@ const setMapStore = (map: mapboxgl.Map) => {
   mapStore.set({
     bbox,
     geoType: getGeoTypeForCurrentZoom(zoom),
+    zoom: zoom,
   });
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type GeoType = "ew" | "lad" | "msoa" | string;
 export type MapState = {
   bbox: Bbox;
   geoType: GeoType;
+  zoom: number;
 };
 
 export type Topic = typeof topics[0];


### PR DESCRIPTION
### What

commit 3d2cfc598e0b7c9768edda8ff7d1c9177443a2f4 (HEAD -> feature/snap-bbox-requests-to-map-tile, origin/feature/snap-bbox-requests-to-map-tile)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue May 10 12:05:54 2022 +0100

    spatialHelpers.getQuantisedBbox snaps viewport bbox to slippy max x,y

    snapBboxToMapGrid takes viewport bbox and snaps corners to nearest
    slippy map x, y points for current zoom level (rounded down to nearest
    integer value).
    These changes needed to reduce variability in bbox requests made to
    the api, in order to better make use of request-keyed serverside cache.

### How to review

run tests with `npm run test`
Run locally, check it works

### Who can review

Anyone