### PR TITLE
load census data + breaks from s3 flat files rather than api

### DIFF
--- a/src/components/CategoryPage.svelte
+++ b/src/components/CategoryPage.svelte
@@ -38,20 +38,19 @@
   $: if ($mapStore) {
     let codes = getCodesForCategory(params.topic, params.variable, params.classification, params.category);
     // TEMP do not load data for OAs as its not available
-    if ($mapStore.geoType != "oa") {
-      setVizStore({
-        ...codes,
-        geoType: $mapStore.geoType, // todo remove
-        geoCode: selectedGeographyGeoCode,
-        bbox: $mapStore.bbox,
-        zoom: $mapStore.zoom,
-      });
-      setSelectedGeographyVariableStore({
-        totalCode: codes.totalCode,
-        categoryCodes: codes.categoryCodes,
-        geoCode: selectedGeographyGeoCode,
-      });
-    }
+    setVizStore({
+      totalCode: codes.totalCode,
+      categoryCode: codes.categoryCode,
+      geoType: $mapStore.geoType, // todo remove
+      geoCode: selectedGeographyGeoCode,
+      bbox: $mapStore.bbox,
+      zoom: $mapStore.zoom,
+    });
+    setSelectedGeographyVariableStore({
+      totalCode: codes.totalCode,
+      categoryCodes: codes.categoryCodes,
+      geoCode: selectedGeographyGeoCode,
+    });
   }
 </script>
 

--- a/src/data/api.ts.test.ts
+++ b/src/data/api.ts.test.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 import * as api from "./api";
 
-describe("memFetchQuery", () => {
+describe("memFetchTileData", () => {
   beforeEach(() => {
     // Mocking external calls from fetchQuery here, as seems difficult to mock the memoized function itself in vitest.
     vi.mock("d3-dsv");
@@ -17,73 +17,86 @@ describe("memFetchQuery", () => {
     vi.clearAllMocks();
   });
   test("fetches data on each call, given unique arguments", () => {
-    api.memFetchQuery({
-      totalCode: "totalCode1",
+    api.memFetchTileData({
       categoryCode: "categoryCode1",
       geoType: "GeoType1",
-      bbox: {
-        east: 1,
-        north: 2,
-        west: 3,
-        south: 4,
+      tile: {
+        tilename: "1",
+        bbox: {
+          east: 1,
+          north: 2,
+          west: 3,
+          south: 4,
+        },
       },
     });
-    api.memFetchQuery({
-      totalCode: "totalCode2",
+    api.memFetchTileData({
       categoryCode: "categoryCode2",
       geoType: "GeoType2",
-      bbox: {
-        east: 4,
-        north: 5,
-        west: 6,
-        south: 7,
+      tile: {
+        tilename: "2",
+        bbox: {
+          east: 4,
+          north: 5,
+          west: 6,
+          south: 7,
+        },
       },
     });
-    api.memFetchQuery({
-      totalCode: "totalCode3",
+    api.memFetchTileData({
       categoryCode: "categoryCode3",
       geoType: "GeoType3",
-      bbox: {
-        east: 8,
-        north: 9,
-        west: 10,
-        south: 11,
+      tile: {
+        tilename: "3",
+        bbox: {
+          east: 8,
+          north: 9,
+          west: 10,
+          south: 11,
+        },
       },
+      
     });
     expect(global.fetch).toBeCalledTimes(3);
   });
   test("fetches data only once when called repeatedly with the same arguments", () => {
-    api.memFetchQuery({
-      totalCode: "totalCode4",
+    api.memFetchTileData({
       categoryCode: "categoryCode4",
       geoType: "GeoType4",
-      bbox: {
-        east: 1,
-        north: 2,
-        west: 3,
-        south: 4,
+      tile: {
+        tilename: "4",
+        bbox: {
+          east: 1,
+          north: 2,
+          west: 3,
+          south: 4,
+        },
       },
     });
-    api.memFetchQuery({
-      totalCode: "totalCode4",
+    api.memFetchTileData({
       categoryCode: "categoryCode4",
       geoType: "GeoType4",
-      bbox: {
-        east: 1,
-        north: 2,
-        west: 3,
-        south: 4,
+      tile: {
+        tilename: "4",
+        bbox: {
+          east: 1,
+          north: 2,
+          west: 3,
+          south: 4,
+        },
       },
     });
-    api.memFetchQuery({
-      totalCode: "totalCode4",
+    api.memFetchTileData({
       categoryCode: "categoryCode4",
       geoType: "GeoType4",
-      bbox: {
-        east: 1,
-        north: 2,
-        west: 3,
-        south: 4,
+      tile: {
+        tilename: "4",
+        bbox: {
+          east: 1,
+          north: 2,
+          west: 3,
+          south: 4,
+        },
       },
     });
     expect(global.fetch).toBeCalledTimes(1);
@@ -107,36 +120,30 @@ describe("memFetchBreaks", () => {
   });
   test("fetches data on each call, given unique arguments", () => {
     api.memFetchBreaks({
-      totalCode: "totalCode1",
-      categoryCodes: ["categoryCode1", "categoryCode2", "categoryCode3"],
+      categoryCode: "categoryCode1",
       geoType: "GeoType1",
     });
     api.memFetchBreaks({
-      totalCode: "totalCode2",
-      categoryCodes: ["categoryCode4", "categoryCode5", "categoryCode6"],
+      categoryCode: "categoryCode4",
       geoType: "GeoType2",
     });
     api.memFetchBreaks({
-      totalCode: "totalCode3",
-      categoryCodes: ["categoryCode7", "categoryCode8", "categoryCode9"],
+      categoryCode: "categoryCode7",
       geoType: "GeoType3",
     });
     expect(global.fetch).toBeCalledTimes(3);
   });
   test("fetches data only once when called repeatedly with the same arguments", () => {
     api.memFetchBreaks({
-      totalCode: "totalCode4",
-      categoryCodes: ["categoryCode10", "categoryCode11", "categoryCode12"],
+      categoryCode: "categoryCode10",
       geoType: "GeoType4",
     });
     api.memFetchBreaks({
-      totalCode: "totalCode4",
-      categoryCodes: ["categoryCode10", "categoryCode11", "categoryCode12"],
+      categoryCode: "categoryCode10",
       geoType: "GeoType4",
     });
     api.memFetchBreaks({
-      totalCode: "totalCode4",
-      categoryCodes: ["categoryCode10", "categoryCode11", "categoryCode12"],
+      categoryCode: "categoryCode10",
       geoType: "GeoType4",
     });
     expect(global.fetch).toBeCalledTimes(1);

--- a/src/data/setVizStore.ts
+++ b/src/data/setVizStore.ts
@@ -7,13 +7,11 @@ import { getCategoryInfo } from "../helpers/categoryHelpers";
 export const setVizStore = async (args: {
   totalCode: string;
   categoryCode: string;
-  categoryCodes: string[];
   geoType: GeoType;
   geoCode: string;
   bbox: Bbox;
   zoom: number;
 }) => {
-  // normalise bbox to slippy map X,Y tile grid before fetching, to increase cachability
   const [places, breaksData] = await Promise.all([fetchTileDataForBbox(args), memFetchBreaks(args)]);
   vizStore.set({
     breaks: breaksData.breaks[args.categoryCode].map((breakpoint) => parseFloat(breakpoint) * 100),

--- a/src/helpers/spatialHelper.ts
+++ b/src/helpers/spatialHelper.ts
@@ -42,4 +42,3 @@ export const englandAndWales: GeographyInfo = {
     ],
   },
 };
-


### PR DESCRIPTION
refactor api.ts functions (nb module probably wants renaming!)
to pull data from s3 flat files (for census map data and
census data breaks) as well as API (for geo info and selected
geography data). This change needed as PoC for shift to
flat-file for everything.

### What

Describe what you have changed and why.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
