### PR TITLE
remove on-load call to fetchSelectedGeographyData in layout.svelte

### DIFF
--- a/src/components/Layout.svelte
+++ b/src/components/Layout.svelte
@@ -7,10 +7,6 @@
   import { getSelectedGeography } from "../helpers/categoryHelpers";
   import { setSelectedGeographyStore } from "../data/setSelectedGeographyStore";
 
-  $: if ($page) {
-    const g = getSelectedGeography($page.url);
-    setSelectedGeographyStore({ geoCode: g.geoCode, geoType: g.geoType });
-  }
 </script>
 
 <div class="xl:tw-absolute tw-inset-0 xl:tw-flex tw-flex-col">


### PR DESCRIPTION
Remove call to fetchSelectedGeographyData made on import / load
of layout.svelte, as:
-  this was running on the server (where the API is not always
available) and was breaking CI
- the UI elements informed by fetchSelectedGeographyData are being
deprecated

### What

Remove call to fetchSelectedGeographyData made on import / load
of layout.svelte, as:
-  this was running on the server (where the API is not always
available) and was breaking CI
- the UI elements informed by fetchSelectedGeographyData are being
deprecated

### How to review

read the code

### Who can review

Anyone