### PR TITLE
remove unneccessary looping from renderMapViz

### DIFF
--- a/src/data/setVizStore.ts
+++ b/src/data/setVizStore.ts
@@ -14,6 +14,7 @@ export const setVizStore = async (args: {
 }) => {
   const [places, breaksData] = await Promise.all([fetchTileDataForBbox(args), memFetchBreaks(args)]);
   vizStore.set({
+    geoType: args.geoType,
     breaks: breaksData.breaks[args.categoryCode].map((breakpoint) => parseFloat(breakpoint) * 100),
     minMaxVals: breaksData.minMax[args.categoryCode],
     places: places.map((row) => parsePlaceData(row, args.totalCode, args.categoryCode)),

--- a/src/map/renderMapViz.ts
+++ b/src/map/renderMapViz.ts
@@ -5,22 +5,15 @@ import { layers } from "./layers";
 export const renderMapViz = (map: mapboxgl.Map, data: VizData) => {
   if (!data) return;
 
-  // TODO: we only only to do this for the currently visible geotype
-  layers.forEach((l) => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore (typings for this overload are currently missing)
-    const features = map.queryRenderedFeatures({ layers: [`${l.name}-features`] });
+  const layer = layers.find((l) => l.name == data.geoType);
 
-    features.forEach((f) => {
-      const dataForFeature = data.places.find((p) => p.geoCode === f.id);
-
-      if (dataForFeature) {
-        map.setFeatureState(
-          { source: l.name, sourceLayer: l.sourceLayer, id: f.id },
-          { colour: getChoroplethColour(dataForFeature.percentage, data.breaks) },
-        );
-      }
-    });
+  // assume all data in viz store relates to a place on the map that is currently in view, so no need to filter to
+  // rendered features only
+  data.places.forEach((p) => {
+    map.setFeatureState(
+      { source: layer.name, sourceLayer: layer.sourceLayer, id: p.geoCode },
+      { colour: getChoroplethColour(p.percentage, data.breaks) },
+    );
   });
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type Category = typeof topics[0]["variables"][0]["categories"][0];
 export type VariableData = { [catCode: string]: { count: number; total: number; percentage: number } };
 
 export type VizData = {
+  geoType: GeoType;
   breaks: number[];
   minMaxVals: number[];
   places: { geoCode: string; count: number; percentage: number; total: number }[];


### PR DESCRIPTION
### What

refactor renderMapViz to avoid looping through all layers and
all features when setting chloropleth colors for features
with data.

### How to review

- pull code and run locally with `npm install && npm run dev` 
- select a category from the 'education' topic (all others not yet available)
- zoom / pan the map to check it gets colored in

### Who can review

Anyone