### PR TITLE
consume ratioToTotal census data direct from flat files

### DIFF
--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -4,18 +4,13 @@ import mem from "mem";
 import QuickLRU from "quick-lru";
 import { bboxToDataTiles, englandAndWales } from "../helpers/spatialHelper";
 
-const s3BaseUrl = "https://find-insights-db-dumps.s3.eu-central-1.amazonaws.com/education";
+const s3BaseUrl = "https://find-insights-db-dumps.s3.eu-central-1.amazonaws.com/quads";
 
 /*
   Fetch place data files for all data 'tiles' (predefined coordinate grid squares) that intersect with current viewport 
   bounding box.
 */
-export const fetchTileDataForBbox = async (args: {
-  totalCode: string;
-  categoryCode: string;
-  geoType: GeoType;
-  bbox: Bbox;
-}) => {
+export const fetchTileDataForBbox = async (args: { categoryCode: string; geoType: GeoType; bbox: Bbox }) => {
   // get all intersecting data tiles
   const dataTiles = bboxToDataTiles(args.bbox, args.geoType);
 

--- a/src/data/setVizStore.ts
+++ b/src/data/setVizStore.ts
@@ -5,7 +5,6 @@ import { vizStore } from "../stores/stores";
 import { getCategoryInfo } from "../helpers/categoryHelpers";
 
 export const setVizStore = async (args: {
-  totalCode: string;
   categoryCode: string;
   geoType: GeoType;
   geoCode: string;
@@ -15,19 +14,16 @@ export const setVizStore = async (args: {
   const [places, breaksData] = await Promise.all([fetchTileDataForBbox(args), memFetchBreaks(args)]);
   vizStore.set({
     geoType: args.geoType,
-    breaks: breaksData.breaks[args.categoryCode].map((breakpoint) => parseFloat(breakpoint) * 100),
+    breaks: breaksData.breaks[args.categoryCode],
     minMaxVals: breaksData.minMax[args.categoryCode],
-    places: places.map((row) => parsePlaceData(row, args.totalCode, args.categoryCode)),
+    places: places.map((row) => parsePlaceData(row, args.categoryCode)),
     params: getCategoryInfo(args.categoryCode),
   });
   return Promise.resolve();
 };
 
-// TODO do we actually use the percentages now?
-const parsePlaceData = (row: dsv.DSVRowString<string>, totalCode: string, categoryCode: string) => {
+const parsePlaceData = (row: dsv.DSVRowString<string>, categoryCode: string) => {
   const geoCode = row.geography_code;
-  const total = parseInt(row[totalCode]);
-  const count = parseInt(row[categoryCode]);
-  const percentage = (count / total) * 100;
-  return { geoCode, count, total, percentage };
+  const ratioToTotal = parseFloat(row[categoryCode]);
+  return { geoCode, ratioToTotal };
 };

--- a/src/helpers/mapKeyHelper.ts
+++ b/src/helpers/mapKeyHelper.ts
@@ -1,15 +1,15 @@
 export const calculateDataBreakBuckets = (breaks: number[], min: number) => {
-  const fullBreaks = [min, ...breaks];
+  const fullBreaksPercentages = [min, ...breaks].map((breakRatio) => breakRatio * 100);
   const stringsArr = [];
   for (let i = 0; i < 5; i++) {
-    const lowVal = (Math.round(fullBreaks[i] * 10) / 10).toFixed(1);
+    const lowVal = (Math.round(fullBreaksPercentages[i] * 10) / 10).toFixed(1);
     let upperVal;
     if (i === 4) {
       //for highest bucket, set upperVal to the highest data value
-      upperVal = (Math.round(fullBreaks[i + 1] * 10) / 10).toFixed(1);
+      upperVal = (Math.round(fullBreaksPercentages[i + 1] * 10) / 10).toFixed(1);
     } else {
       //for all other buckets, set upperVal to the start of the next bucket minus 0.1
-      upperVal = (Math.round(fullBreaks[i + 1] * 10) / 10 - 0.1).toFixed(1);
+      upperVal = (Math.round(fullBreaksPercentages[i + 1] * 10) / 10 - 0.1).toFixed(1);
     }
     stringsArr.push(`${lowVal}% - ${upperVal}%`);
   }

--- a/src/map/renderMapViz.ts
+++ b/src/map/renderMapViz.ts
@@ -6,13 +6,12 @@ export const renderMapViz = (map: mapboxgl.Map, data: VizData) => {
   if (!data) return;
 
   const layer = layers.find((l) => l.name == data.geoType);
-
   // assume all data in viz store relates to a place on the map that is currently in view, so no need to filter to
   // rendered features only
   data.places.forEach((p) => {
     map.setFeatureState(
       { source: layer.name, sourceLayer: layer.sourceLayer, id: p.geoCode },
-      { colour: getChoroplethColour(p.percentage, data.breaks) },
+      { colour: getChoroplethColour(p.ratioToTotal, data.breaks) },
     );
   });
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export type VizData = {
   geoType: GeoType;
   breaks: number[];
   minMaxVals: number[];
-  places: { geoCode: string; count: number; percentage: number; total: number }[];
+  places: { geoCode: string; ratioToTotal: number }[];
   params: {
     topic: Topic;
     variable: Variable;


### PR DESCRIPTION
Consume ratioToTotal census data directly from csv files
rather than calculate as census data value / total for each
geography.

These changes needed to minimise csv file size
