### PR TITLE
move geolookup file to s3 as static file not included in node build

### DIFF
--- a/src/components/Search.svelte
+++ b/src/components/Search.svelte
@@ -44,7 +44,7 @@
         labelText={label}
         {invertTextColor}
         {id}
-        autosuggestData={"/geoLookup.json"}
+        autosuggestData={"https://find-insights-db-dumps.s3.eu-central-1.amazonaws.com/quads/autosuggestData/geoLookup.json"}
         {renderError}
         {header}
         bind:autosuggestValue={userInputValue}


### PR DESCRIPTION
Static file geoLookup.json is referenced by ONS autosuggest feature
but not imported directly. This seems to mean that the vite build
system is not aware of its existence and does not bundle it.
Moving the file to s3 fixes the issue.

### What

Describe what you have changed and why.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
