### PR TITLE
remove redundant (and broken) build stage from ci unit test script

### DIFF
--- a/ci/scripts/unit.sh
+++ b/ci/scripts/unit.sh
@@ -2,6 +2,6 @@
 
 pushd dp-census-atlas
   npm install --silent
-  npm run build
+  npm run build:sandbox
   make test
 popd


### PR DESCRIPTION
### What

commit 2c603b94927084be18e48df1827cc344a03077ca (HEAD -> bugfix/fix-ci-unit-tests, origin/bugfix/fix-ci-unit-tests)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Jul 29 10:45:54 2022 +0100

    replace build with build:sandbox in ci unit test script

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
