### PR TITLE
numberUtil.minDecimalPlacesToAntialias prevents map legend showing re…

### DIFF
--- a/src/components/BreaksChart.svelte
+++ b/src/components/BreaksChart.svelte
@@ -5,6 +5,7 @@
   export let selected = null;
   export let lineWidth = 3;
   export let breaks = [0, 20, 40, 60, 80, 100];
+  export let decimalPlaces = 0
   export let colors = ["rgba(234,236,177)", "rgba(169,216,145)", "rgba(0,167,186)", "rgba(0,78,166)", "rgba(0,13,84)"];
   export let suffix = "";
   export let snapTicks = true;
@@ -33,12 +34,12 @@
       class="tick"
       style="left: {i * (100 / (breaks.length - 1))}%; transform: translateX({i == 0 && snapTicks ? '-2px' : '-50%'});"
     >
-      {ratioToPercentage(breaks[i], 0)}<span class="tick-suffix">{suffix}</span>
+      {ratioToPercentage(breaks[i], decimalPlaces)}<span class="tick-suffix">{suffix}</span>
     </div>
   {/each}
   <div class="line" style="right: 0;" />
   <div class="tick" style="right: 0; transform: translateX({snapTicks ? '2px' : '50%'});">
-    {ratioToPercentage(breaks[breaks.length - 1], 0)}<span class="tick-suffix">{suffix}</span>
+    {ratioToPercentage(breaks[breaks.length - 1], decimalPlaces)}<span class="tick-suffix">{suffix}</span>
   </div>
   {#if selected}
     <!-- <div class="marker" style="width: 4px; left: calc({pos(selected, breaks)}% - {lineWidth / 2}px);" /> -->

--- a/src/components/MapLegend.svelte
+++ b/src/components/MapLegend.svelte
@@ -3,7 +3,7 @@
   import { vizStore, selectedGeographyStore } from "../stores/stores";
   import { topicStore } from "../stores/stores";
   import { formatTemplateString } from "../helpers/categoryHelpers";
-  import { ratioToPercentage } from "../util/numberUtil";
+  import { minDecimalPlacesToAntialias, ratioToPercentage } from "../util/numberUtil";
   import { choroplethColours } from "../helpers/choroplethHelpers";
   import { getDefaultChoroplethClassification } from "../helpers/variableHelpers";
 
@@ -21,6 +21,8 @@
   $: defaultChoroplethClassification = getDefaultChoroplethClassification(variable);
   $: categorySlug = params.category;
   $: category = variable ? defaultChoroplethClassification.categories.find((c) => c.slug === categorySlug) : undefined;
+  $: breaks = $vizStore ? [$vizStore?.minMaxVals[0], ...$vizStore.breaks] : undefined
+  $: decimalPlaces = breaks ? minDecimalPlacesToAntialias(breaks) : 0
 </script>
 
 <!-- todo: new design for all four states -->
@@ -66,7 +68,8 @@
         <BreaksChart
           selected={categoryValueForSelectedGeography}
           suffix="%"
-          breaks={$vizStore ? [$vizStore?.minMaxVals[0], ...$vizStore.breaks] : undefined}
+          breaks={breaks}
+          decimalPlaces = {decimalPlaces}
           colors={choroplethColours}
         />
       {/if}

--- a/src/util/numberUtil.ts
+++ b/src/util/numberUtil.ts
@@ -19,9 +19,23 @@ export function numberToWords(n: number) {
   return capitalizeFirstLetter(number2words(n));
 }
 
-export function ratioToPercentage(r: number, decimalPlaces?: number) {
+export function ratioToPercentage(r: number, decimalPlaces?: number): string {
   if (typeof decimalPlaces !== undefined) {
     return (r * 100).toFixed(decimalPlaces);
   }
-  return r * 100;
+  return (r * 100).toFixed(0);
+}
+
+/*
+  Return minimum decimal places needed to round ratios while ensuring they remain unique
+*/
+export function minDecimalPlacesToAntialias(ratios: number[]): number {
+  let decimalPlaces = 0;
+  let percentages = ratios.map((n) => ratioToPercentage(n, decimalPlaces));
+  // iterate decimalPlaces until percentages contains only unique values
+  while (new Set(percentages).size != ratios.length) {
+    decimalPlaces += 1;
+    percentages = ratios.map((n) => ratioToPercentage(n, decimalPlaces));
+  }
+  return decimalPlaces;
 }


### PR DESCRIPTION
…peated values

### What

commit e51060cb90283482d923c8c77c8e9bee505310da (HEAD -> fix/22-fix-scale-for-small-values, origin/fix/22-fix-scale-for-small-values)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Aug 10 10:46:09 2022 +0100

    numberUtil.minDecimalPlacesToAntialias prevents map legend showing repeated values

### How to review
Read the code etc,
check out the netlify preview, and navigate to population, marital status, then seperated (but still legally married). You should see the map legend display a unique set of scale numbers, rather than the aliased set seen in the trello ticket here: https://trello.com/c/0QAy4rxd/22-fix-scale-for-small-values 


### Who can review

Anyone