### PR TITLE
Feat/download service integration

### DIFF
--- a/env/dev.sh
+++ b/env/dev.sh
@@ -2,13 +2,13 @@
 
 export SKADAPTER=""
 # allow override of these values with locally set ones
-if [ -z $VITE_GEODATA_BASE_URL]; then
+if [ -z ${VITE_GEODATA_BASE_URL+x} ]; then
 export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/quads"
 else
 export VITE_GEODATA_BASE_URL=$VITE_GEODATA_BASE_URL
 fi
 
-if [ -z $VITE_CONTENT_JSONS]; then
+if [ -z ${VITE_CONTENT_JSONS+x} ]; then
 export VITE_CONTENT_JSONS='[
     "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2011-new-format-content.json"
 ]'

--- a/env/pub.sh
+++ b/env/pub.sh
@@ -1,10 +1,10 @@
-# env vars needed to run on netlify
+# env vars needed to build for ONS publishing env
 
-export SKADAPTER=""
-export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/quads"
+export SKADAPTER="node"
+export VITE_GEODATA_BASE_URL="this will need to be: <publishing atlas url>/files-proxy/<path to data files>"
 export VITE_CONTENT_JSONS='[
-    "https://localhost:28100/files-proxy/Education/2011-Education-new-format-content.json"
+    "this will need to be: <publishing atlas url>/files-proxy/<path to config jsons>"
 ]'
-export VITE_APP_BASE_PATH=""
+export VITE_APP_BASE_PATH="/census-atlas"
 export VITE_IS_PUBLISHING="true"
-export VITE_PUBLISHING_DOWNLOAD_URL="http://localhost:23201/v1/downloads-new"
+export VITE_PUBLISHING_DOWNLOAD_URL="this will need to be: <publishing API url>/v1/downloads-new"

--- a/env/pub.sh
+++ b/env/pub.sh
@@ -1,0 +1,10 @@
+# env vars needed to run on netlify
+
+export SKADAPTER=""
+export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/quads"
+export VITE_CONTENT_JSONS='[
+    "https://localhost:28100/files-proxy/Education/2011-Education-new-format-content.json"
+]'
+export VITE_APP_BASE_PATH=""
+export VITE_IS_PUBLISHING="true"
+export VITE_PUBLISHING_DOWNLOAD_URL="http://localhost:23201/v1/downloads-new"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build:netlify": ". env/netlify.sh && npm run build",
     "build:sandbox": ". env/sandbox.sh && npm run build && ./workaround-sveltekit-3726.sh",
     "build:prod": ". env/prod.sh && npm run build && ./workaround-sveltekit-3726.sh",
+    "build:publishing": ". env/pub.sh && npm run build && ./workaround-sveltekit-3726.sh",
     "package": "svelte-kit package",
     "preview": "svelte-kit preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",

--- a/src/env.ts
+++ b/src/env.ts
@@ -36,3 +36,16 @@ if (appBasePath != "" && appBasePath[0] != "/") {
   throw new Error(`Env var VITE_APP_BASE_PATH='${appBasePath}' must be either blank or start with a '/'.`);
 }
 export { appBasePath };
+
+// isPublishing is an optional boolean that defaults to false
+const isPublishing = import.meta.env.VITE_IS_PUBLISHING === "true" ? true : false;
+export { isPublishing };
+
+// publishingDownloadUrlw must be a valid URL if isPublishing is true
+const publishingDownloadUrl = import.meta.env.VITE_PUBLISHING_DOWNLOAD_URL;
+if (isPublishing && isNotUrl(publishingDownloadUrl)) {
+  throw new Error(
+    `Env var VITE_PUBLISHING_DOWNLOAD_URL='${publishingDownloadUrl}' must be set to a valid URL if IS_PUBLISHING='true'.`,
+  );
+}
+export { publishingDownloadUrl };

--- a/src/routes/files-proxy/[...path].ts
+++ b/src/routes/files-proxy/[...path].ts
@@ -1,0 +1,37 @@
+import type { RequestHandler } from "@sveltejs/kit";
+import { isPublishing, publishingDownloadUrl } from "../../env";
+
+// proxy for using the publishing download service, which does not set CORS headers and so cannot be used directly
+export const get: RequestHandler = async ({ request, params }) => {
+  // 403 if we're not in publishing
+  if (!isPublishing) {
+    return {
+      status: 403,
+      body: "This endpoint is only available in publishing!",
+    };
+  }
+
+  // get florence access token from cookies
+  const cookies = request.headers.get("cookie") || "";
+  const florence_cookies = cookies
+    .split(";")
+    .map((c) => c.trim())
+    .filter((c) => c.startsWith("access_token="));
+
+  // 401 if not logged in to florence
+  if (florence_cookies.length === 0) {
+    return {
+      status: 401,
+      body: "You must be logged in to florence to use this endpoint!",
+    };
+  }
+
+  // get requested files from download-service
+  const florence_cookie = florence_cookies[0].split("=")[1];
+  const res = await fetch(`${publishingDownloadUrl}/${params.path}`, {
+    headers: {
+      "X-Florence-Token": florence_cookie,
+    },
+  });
+  return res;
+};


### PR DESCRIPTION
### What

commit 8b44eda8f35e67803d0ec055227823e5a20ee007 (HEAD -> feat/download-service-integration, origin/feat/download-service-integration)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Aug 16 15:22:49 2022 +0100

    env config for publishing env(s)

    Add env/pub.sh (with placeholders) for build config for publishing
    environments (possibly will need for prod/publishing and sandbox/publishing
    etc, will cross that bridge when we come to it).

commit 9b0195bb8db2472809306dc8ff906ff53aa5164d
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Aug 16 15:04:48 2022 +0100

    add pub env

commit d7811703690de16779dead73c0df250ee6b19f81
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Aug 15 21:06:12 2022 +0100

    files-proxy endpoint for auth + CORS headers when calling pub download-service

    Add new endpoint route (files-proxy) to proxy calls to the download-service
    in the publishing env, as in publishing mode this service does not add
    CORS headers and requires authorisation,

    files-proxy endpoint is controlled by two vite env vars, VITE_IS_PUBLISHING
    (this will turn the endpoint on or off) and VITE_PUBLISHING_DOWNLOAD_URL,
    which is the url that the endpoint will proxy requests to/from.

commit 19468d8f14dd54111ef8fe667244fc4eee094f72
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Aug 15 16:07:40 2022 +0100

    fix overridable env var exports in dev.sh

    The boolean checks for already-set env vars in dev.sh (intended to
    allow easy config changes when running the dev app) didn't work due
    to bash syntax errors.

### How to review

Read the code, check the previews. Testing this against publishing is pretty involved: 
- need to get and tweak the https://github.com/ONSdigital/dp-static-files-compose setup to have two instances of the API router (one publishing, one web) 
- apply the download-service fix in this PR: https://github.com/ONSdigital/dp-download-service/pull/121
- run the tweaked docker-compose from the dp-static-files-compose repo
- add a content.json file to the local static files service (unpublished) - easiest way to do that is use the dp-geodata-api's filescli: https://github.com/ONSdigital/dp-geodata-api/tree/develop/cmd/filescli
- reference the content.json in the VITE_CONTENT_JSONS var in env/pub.sh, VIA the filesproxy, e.g. http://localhost:28100/files-proxy/<path to the file you added to the local files service)
- reference real content in the VITE_GEODATA_BASE_URL in env/pub.sh (e.g. https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/quads)
- reference the local files service in VITE_PUBLISHING_DOWNLOAD_URL in env/pub.sh (e.g. http://localhost/23200/v1/downloads-new)
- start up the atlas
- you shouldn't be able to load the content.json at first - then if you go to http://localhost:8081/florence/login and log in with the standard password (ask me if you don't have this), you should be able to load the unpublished content.json

### Who can review

Anyone