### PR TITLE
add mnemonic to output for variable desc to csv script

### DIFF
--- a/content/cantabular_metadata_to_content_json.py
+++ b/content/cantabular_metadata_to_content_json.py
@@ -37,7 +37,7 @@ def category_from_cantabular_csv_row(csv_row: dict) -> CensusCategory:
     return CensusCategory(
         # combine mapping label with source values to make code? ToDo - discuss this!
         name=csv_row["External_Mapping_Label_English"].strip(),
-        code=f'{csv_row["External_Mapping_Label_English"].strip()}-{csv_row["Source_Value"].strip()}',
+        code=f'{slugify(csv_row["External_Mapping_Label_English"].strip())}-{csv_row["Source_Value"].strip()}',
         slug=slugify(csv_row["External_Mapping_Label_English"].strip()),
         legend_str_1="",
         legend_str_2="",
@@ -138,5 +138,5 @@ def main(cantabular_metadata_dir: Path, output_dir: Path):
 
 if __name__ == "__main__":
     metadata_dir = Path(sys.argv[1])
-    output_dir = "content_jsons"
+    output_dir = Path("content_jsons")
     main(metadata_dir, output_dir)

--- a/content/content_json_variable_desc_to_csv.py
+++ b/content/content_json_variable_desc_to_csv.py
@@ -29,8 +29,9 @@ def main():
         for variable in topic["variables"]:
             csv_content.append({
                 "ADMIN_topic": topic["name"],
-                "ADMIN_variable": variable["name"],
-                "ADMIN_old_desc": variable["desc"],
+                "ADMIN_variable_name": variable["name"],
+                "ADMIN_variable_mnemonic": variable["code"],
+                "ADMIN_long_desc": variable["desc"],
                 "EDIT_THIS_new_desc": variable["desc"]
             })
     


### PR DESCRIPTION
### What

commit 2ead8dfacff7708d0a12f1eab7fad8b5730eee48 (HEAD -> feat/tweak-content-scripts-additional-metada-file-generators, origin/feat/tweak-content-scripts-additional-metada-file-generators, feat/tests-for-content-scripts)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Aug 24 15:12:23 2022 +0100

    add mnemonic to output for variable desc to csv script

    - add mnemonic to ouput from content_json_variable_desc_to_csv.py for
    easier processing

    - fix issue with input paths not being python Paths in various scripts.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
