### PR TITLE
Feat/content datasets

### DIFF
--- a/content/census_objects.py
+++ b/content/census_objects.py
@@ -61,6 +61,12 @@ class CensusCategory:
 
 
 @dataclass
+class CensusDataset:
+    code: str
+    variable: str
+    classification: str
+
+@dataclass
 class CensusClassification:
     """A classification as found in content.json."""
 
@@ -70,6 +76,9 @@ class CensusClassification:
     choropleth_default: bool
     dot_density_default: bool
     categories: list[CensusCategory]
+    dataset: str = ""
+    derivable_from_dataset: str = ""
+    comparison_2011_data_available: bool = False
     _variable_code: str = ""
 
     def gather_categories(self, category_list: list[CensusCategory]) -> None:
@@ -105,6 +114,9 @@ class CensusClassification:
                 _source_value=cat_to_take_values_from._source_value
             ))
 
+    def find_dataset(self, dataset_list: list[CensusDataset]) -> None:
+        self.dataset = next((d.code for d in dataset_list if d.classification == self.code), "")
+
 
     def is_valid(self) -> bool:
         """
@@ -132,7 +144,9 @@ class CensusClassification:
         output_params = {
             "code": self.code,
             "slug": self.slug,
-            "desc": self.desc
+            "desc": self.desc,
+            "dataset": self.dataset,
+            "derivable_from_dataset": self.derivable_from_dataset,
         }
 
         if self.choropleth_default:
@@ -140,6 +154,9 @@ class CensusClassification:
 
         if self.dot_density_default:
             output_params["dot_density_default"] = self.dot_density_default
+
+        if self.comparison_2011_data_available:
+            output_params["comparison_2011_data_available"] = self.comparison_2011_data_available
 
         output_params["categories"] = [c.to_jsonable() for c in self.categories]
 
@@ -177,6 +194,13 @@ class CensusVariable:
                 c.legend_str_1 = f"of {UNIT_PLURALS[self.units.lower()]} in {{location}}"
                 c.legend_str_2 = "are"
                 c.legend_str_3 = c.name.lower()
+
+    def set_derivable_from_dataset(self) -> None:
+        classifications_w_datasets = [c for c in self.classifications if c.dataset != ""]
+        for c in self.classifications:
+            c.derivable_from_dataset = ",".join([
+                cd.dataset for cd in classifications_w_datasets if len(cd.categories) > len(c.categories)
+            ])
 
     def is_valid(self) -> bool:
         """
@@ -316,6 +340,9 @@ def classification_from_content_json(content_json: dict) -> CensusClassification
         desc=content_json["desc"],
         choropleth_default=content_json.get("choropleth_default", False),
         dot_density_default=content_json.get("dot_density_default", False),
+        dataset=content_json.get("dataset", ""),
+        derivable_from_dataset=content_json.get("derivable_from_dataset", ""),
+        comparison_2011_data_available=content_json.get("comparison_2011_data_available", False),
         categories=[category_from_content_json(c) for c in content_json["categories"]],
     )
 

--- a/content/census_objects.py
+++ b/content/census_objects.py
@@ -126,7 +126,7 @@ class CensusClassification:
 
         for prop, value in vars(self).items():
             if isinstance(value, str) and not prop.startswith("_") and value == "":
-                print(f"** Blank property {prop} found in variable {self.code} **")
+                print(f"** Blank property {prop} found in classification {self.code} **")
                 is_valid = False
 
         if len(self.categories) == 0:

--- a/content/content_json_to_excel.py
+++ b/content/content_json_to_excel.py
@@ -75,7 +75,13 @@ def main(content_json_fn: Path, output_dir: Path, index_csv_fn: Path or None) ->
             for classification in variable.classifications:
                 ws.cell(row=row, column=column, value=classification.code)
                 row +=1
-                ws.cell(row=row, column=column, value="")
+                ws.cell(row=row, column=column, value="Dataset:")
+                row +=1
+                ws.cell(row=row, column=column, value=classification.dataset)
+                row +=1
+                ws.cell(row=row, column=column, value="Derivable From Dataset:")
+                row +=1
+                ws.cell(row=row, column=column, value=classification.derivable_from_dataset)
                 row +=1
                 ws.cell(row=row, column=column, value="Categories:")
                 row +=1

--- a/content/filter_content_json_to_rich_content_spec.py
+++ b/content/filter_content_json_to_rich_content_spec.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+"""
+Filter content.json file with all variables + classifications (first CL arg) to only those referenced in rich content
+spec csv file (second CL arg)
+
+Output will be written to <path to input content.json>/<name of input content.json>-atlas-content-<todays date>.json.
+"""
+
+import csv
+from dataclasses import dataclass
+from datetime import datetime
+import json
+from pathlib import Path
+import sys
+
+from census_objects import (
+    CensusVariable,
+    CensusTopic,
+    CensusRelease,
+    topic_from_content_json
+)
+
+
+# csv file encoding. NB - might want to check this if you get weird characters in the metadata output
+METADATA_FILE_ENCODING = "utf-8-sig'"
+
+
+@dataclass
+class RichContentSpecRow:
+    """All needed config values from a row from the rich content spec csv file."""
+    dataset: str
+    dataset_classification: str
+    additional_atlas_classifications: list[str]
+    choropleth_default_classification: str
+    dot_density_default_classification: str
+    comparison_2011: bool
+
+    def to_str(self):
+        """Simple string representation for error logging"""
+        return f"topic: {self.dataset}, variable: {self.variable}"
+
+
+def load_spec_rows_from_csv(csv_fn: Path) -> list[RichContentSpecRow]:
+    """
+    load_spec_rows_from_csv to list of RichContentSpecRow. NB only rows with 'Y' in the
+    '2021 data Required for Census Atlas?` column will be processed.
+    """
+    output = []
+    with open(csv_fn, "r", encoding=METADATA_FILE_ENCODING) as f:
+        for raw_row in csv.DictReader(f):
+            if raw_row["2021 data Required for Census Atlas?"].strip().lower() == "y":
+                output.append(RichContentSpecRow(
+                    dataset=raw_row["dataset_mnemonic"],
+                    dataset_classification=raw_row["classification_mnemonic"].split("(")[0].strip(),
+                    additional_atlas_classifications=[
+                        c.strip() for c in raw_row["Census Atlas derived classification"].split(",") if c.strip() != ""
+                    ],
+                    choropleth_default_classification=raw_row["Census Atlas choropleth default classification"],
+                    dot_density_default_classification=raw_row["Census Atlas dot density default classification"],
+                    comparison_2011=raw_row["2011 data Required for Census Atlas?(If available)"].lower() == "y",
+                ))
+    return output
+
+
+def load_content(content_file: Path) -> list[CensusTopic]:
+    """Load all census objects defined in content_file."""
+    with open(content_file, "r") as f:
+        raw_topics = json.load(f)
+    return [topic_from_content_json(t) for t in raw_topics]
+
+
+def filter_content(spec_rows: list[RichContentSpecRow], all_topics: list[CensusTopic]) -> list[CensusTopic]:
+    """
+    Filter topics, variables and classifications to fit the classifications specified in spec_rows
+    """
+    topics = []
+    all_variables = []
+    for t in all_topics:
+        all_variables.extend(t.variables)
+
+    for sr in spec_rows:
+        # extract classification codes from spec row NB ensure no duplication here
+        required_cls_codes = [sr.dataset_classification]
+        required_cls_codes.extend(sr.additional_atlas_classifications)
+        required_cls_codes = list(set(required_cls_codes))
+
+        # get topic, variable and classifications for those codes
+        matched_variable = next(
+            v for v in all_variables if required_cls_codes[0] in [c.code for c in v.classifications]
+        )
+        matched_classifications = [c for c in matched_variable.classifications if c.code in required_cls_codes]
+        matched_topic = next(t for t in all_topics if matched_variable.code in [v.code for v in t.variables])
+
+
+        # set classification visualisation flags
+        for c in matched_classifications:
+            if c.code == sr.choropleth_default_classification:
+                c.choropleth_default = True
+            if c.code == sr.dot_density_default_classification:
+                c.dot_density_default = True
+            if sr.comparison_2011 is True:
+                c.comparison_2011_data_available = True
+
+        # make shallow copy of topic with only the variable and classifications needed
+        topic = CensusTopic(
+            name=matched_topic.name,
+            slug=matched_topic.slug,
+            desc=matched_topic.desc,
+            variables=[
+                CensusVariable(
+                    name=matched_variable.name,
+                    code=matched_variable.code,
+                    slug=matched_variable.slug,
+                    desc=matched_variable.desc,
+                    units=matched_variable.units,
+                    classifications=matched_classifications,
+                )
+            ],
+        )
+
+        # merge topics and variables with those already processed, or add it if not
+        processed_topic = next((t for t in topics if t.name == matched_topic.name), None)
+        if processed_topic is not None:
+            # variables can be referenced in multiple rows, so will need to check for already processed variables here
+            processed_variable = next((v for v in processed_topic.variables if v.code == matched_variable.code), None)
+            if processed_variable is not None:
+                processed_variable.classifications.extend(matched_classifications)
+            else:
+                processed_topic.variables.extend(topic.variables)
+        else:
+            topics.append(topic)
+
+    return topics
+
+
+def main(all_content_json_fn: Path, rich_content_spec_fn: Path):
+    spec_rows = load_spec_rows_from_csv(rich_content_spec_fn)
+    all_topics = load_content(all_content_json_fn)
+    topics = CensusRelease(name="all 2021 atlas data", topics=filter_content(spec_rows, all_topics))
+    today = datetime.today().strftime('%Y-%m-%d')
+    output_filename = all_content_json_fn.parent.joinpath(f"{all_content_json_fn.stem}-atlas-{today}.json")
+    if output_filename.exists():
+        print(
+            f"target file {output_filename} already exists! Will not overwrite to avoid loss of work. "
+            f"If you need to start again, please delete {output_filename} first."
+        )
+        return
+    with open(output_filename, "w") as f:
+        json.dump(topics.to_jsonable(), f, indent=2)
+
+
+if __name__ == "__main__":
+    all_content_json_fn = Path(sys.argv[1])
+    rich_content_spec_fn = Path(sys.argv[2])
+    main(all_content_json_fn, rich_content_spec_fn)

--- a/content/list_census_objects_in_content_json.py
+++ b/content/list_census_objects_in_content_json.py
@@ -40,11 +40,24 @@ def main():
 
                 else:
                     for classification in variable["classifications"]:
-                        csv_content.append({
-                            "topic": topic["name"],
-                            "variable_mnemonic": variable["code"],
-                            "classification_mnemonic": classification["code"],
-                        })
+
+                        if census_data_type == "classification":
+                            csv_content.append({
+                                "topic": topic["name"],
+                                "variable_mnemonic": variable["code"],
+                                "classification_mnemonic": classification["code"],
+                            })
+                            continue
+
+                        else: 
+                            for category in classification["categories"]:
+                                csv_content.append({
+                                    "topic": topic["name"],
+                                    "variable_mnemonic": variable["code"],
+                                    "classification_mnemonic": classification["code"],
+                                    "category": category["name"]
+                                })
+
     output_filename = f"{content_json_fp.stem}-all-{census_data_type}-{datetime.today().strftime('%Y-%m-%d')}.csv"
     with open(output_filename, "w") as f:
         writer = csv.DictWriter(f, fieldnames=csv_content[0].keys(), quoting=csv.QUOTE_ALL)

--- a/content/tests/fixtures.py
+++ b/content/tests/fixtures.py
@@ -5,9 +5,8 @@ from census_objects import (
     CensusTopic,
     CensusRelease,
 )
-from filter_content_json_add_viz_flags import (
-    ConfigRow,
-)
+from filter_content_json_add_viz_flags import ConfigRow
+from filter_content_json_to_rich_content_spec import RichContentSpecRow
 
 
 def get_test_category(**kwargs) -> CensusCategory:
@@ -73,4 +72,14 @@ def get_test_config_row(**kwargs) -> ConfigRow:
         classifications=kwargs.get("classifications", "raw"),
         choropleth_default_classification=kwargs.get("choropleth_default_classification", ""),
         dot_density_default_classification=kwargs.get("dot_density_default_classification", ""),
+    )
+
+def get_test_spec_row(**kwargs) -> RichContentSpecRow:
+    return RichContentSpecRow(
+        dataset=kwargs.get("dataset", "test_dataset"),
+        dataset_classification=kwargs.get("dataset_classification", "test_dataset_classification"),
+        additional_atlas_classifications=kwargs.get("additional_atlas_classifications", []),
+        choropleth_default_classification=kwargs.get("choropleth_default_classification", False),
+        dot_density_default_classification=kwargs.get("dot_density_default_classification", False),
+        comparison_2011=kwargs.get("comparison_2011", False)
     )

--- a/content/tests/fixtures.py
+++ b/content/tests/fixtures.py
@@ -29,6 +29,9 @@ def get_test_classification(**kwargs) -> CensusClassification:
         desc=kwargs.get("desc", "test_desc"),
         choropleth_default=kwargs.get("choropleth_default", False),
         dot_density_default=kwargs.get("dot_density_default", False),
+        dataset=kwargs.get("dataset", "test_dataset"),
+        derivable_from_dataset=kwargs.get("test_derivable_from_dataset"),
+        comparison_2011_data_available=kwargs.get("comparison_2011_data_available", False),
         categories=kwargs.get("categories", []),
         _variable_code=kwargs.get("_variable_code", "test_variable_code"),
     )

--- a/content/tests/test_census_objects.py
+++ b/content/tests/test_census_objects.py
@@ -61,6 +61,8 @@ def test_census_classification_to_jsonable_no_vis_flags():
         "code": test_classification.code,
         "slug": test_classification.slug,
         "desc": test_classification.desc,
+        "dataset": test_classification.dataset,
+        "derivable_from_dataset": test_classification.derivable_from_dataset,
         "categories": ["test_category","test_category","test_category"]
     }
     assert returned == expected
@@ -89,6 +91,8 @@ def test_census_classification_to_jsonable_vis_flags():
         "code": test_classification.code,
         "slug": test_classification.slug,
         "desc": test_classification.desc,
+        "dataset": test_classification.dataset,
+        "derivable_from_dataset": test_classification.derivable_from_dataset,
         "choropleth_default": test_classification.choropleth_default,
         "dot_density_default": test_classification.dot_density_default,
         "categories": ["test_category","test_category","test_category"]

--- a/content/tests/test_filter_content_to_rich_content_spec.py
+++ b/content/tests/test_filter_content_to_rich_content_spec.py
@@ -1,0 +1,187 @@
+from unittest import mock
+
+from filter_content_json_to_rich_content_spec import filter_content
+from fixtures import (
+    get_test_classification,
+    get_test_variable,
+    get_test_topic,
+    get_test_spec_row,
+)
+
+
+def test_filter_content_filters_and_copies_required_objects():
+    # GIVEN a CensusTopic that has two CensusVariables with CensusClassifications with id-able names
+    test_topic = get_test_topic()
+
+    test_variable_1 = get_test_variable(code="v1")
+    test_classification_codes_1 = [
+        test_variable_1.code,
+        f"{test_variable_1.code}_3a",
+        f"{test_variable_1.code}_7a",
+        f"{test_variable_1.code}_27a",
+        f"{test_variable_1.code}_86a"
+    ]
+    test_classifications_1 = [get_test_classification(code=code) for code in test_classification_codes_1]
+    test_variable_1.classifications = test_classifications_1
+
+    test_variable_2 = get_test_variable(code="v2")
+    test_classification_codes_2 = [
+        test_variable_2.code,
+        f"{test_variable_2.code}_3a",
+        f"{test_variable_2.code}_7a",
+        f"{test_variable_2.code}_27a",
+        f"{test_variable_2.code}_86a"
+    ]
+    test_classifications_2 = [get_test_classification(code=code) for code in test_classification_codes_2]
+    test_variable_2.classifications = test_classifications_2
+
+    test_topic.variables = [test_variable_1, test_variable_2]
+
+    # AND given a spec row that specifies a subset of those classifications from one variable
+    test_spec_row = get_test_spec_row(
+        dataset_classification=test_classifications_1[0].code,
+        additional_atlas_classifications=[c.code for c in test_classifications_1[3:]]
+    )
+
+    # WHEN we invoke filter_content against our test values
+    returned_topic = filter_content([test_spec_row], [test_topic])[0]
+    # THEN we expect to get a topic back that is NOT our original topic...
+    assert returned_topic != test_topic
+    # ... BUT IS a clone of it
+    for test_prop in ["name", "slug", "desc"]:
+        assert getattr(returned_topic, test_prop) == getattr(test_topic, test_prop)
+
+    # AND we expect our topic to only have a single variable, that is NOT the original target variable...
+    assert len(returned_topic.variables) == 1
+    returned_variable = returned_topic.variables[0]
+    assert returned_variable != test_variable_1
+    # ... BUT IS a clone of it ...
+    for test_prop in ["name", "code", "slug", "desc", "units"]:
+        assert getattr(returned_variable, test_prop) == getattr(test_variable_1, test_prop)
+    # ... which only has the specified classifications attached, in the specified order
+    assert returned_variable.classifications == [test_classifications_1[0], *test_classifications_1[3:]]
+
+
+def test_filter_content_aggregates_variables_from_multiple_spec_rows():
+    # GIVEN a CensusTopic that has a CensusVariables with three CensusClassifications
+    test_topic = get_test_topic()
+    test_variable = get_test_variable(code="v1")
+    test_classifications = [
+        get_test_classification(code="v1_1a"),
+        get_test_classification(code="v1_2a"),
+        get_test_classification(code="v1_3a")
+    ]
+    test_variable.classifications = test_classifications
+    test_topic.variables = [test_variable]
+
+    # AND given two spec rows that each specifie a classification from the same variable
+    test_spec_rows = [
+        get_test_spec_row(dataset_classification="v1_1a"),
+        get_test_spec_row(dataset_classification="v1_3a")
+    ]
+
+    # WHEN we invoke filter_content against our test values
+    returned_topics = filter_content(test_spec_rows, [test_topic])
+    # THEN we expect to get a single topic back
+    assert len(returned_topics) == 1
+
+    # AND we expect our topic to have a single variable, that is NOT the original target variable...
+    returned_variables = returned_topics[0].variables
+    assert len(returned_variables) == 1
+    returned_variable = returned_variables[0]
+    assert returned_variable != test_variable
+    # ... BUT IS a clone of it ...
+    for test_prop in ["name", "code", "slug", "desc", "units"]:
+        assert getattr(returned_variable, test_prop) == getattr(test_variable, test_prop)
+    # ... which only has the specified classifications attached, in the specified order
+    assert returned_variable.classifications == [test_classifications[0], test_classifications[2]]
+
+
+def test_filter_content_adds_visualisation_flags():
+    # GIVEN a CensusTopic that has a CensusVariables with three CensusClassifications
+    test_topic = get_test_topic()
+    test_variable = get_test_variable(code="v1")
+    test_classifications = [
+        get_test_classification(code="v1_1a"),
+        get_test_classification(code="v1_2a"),
+        get_test_classification(code="v1_3a")
+    ]
+    test_variable.classifications = test_classifications
+    test_topic.variables = [test_variable]
+
+    # AND given a spec row that specifies all three classification, and sets visualisation flags for two
+    test_spec_rows = [get_test_spec_row(
+        dataset_classification="v1_1a",
+        additional_atlas_classifications=["v1_2a", "v1_3a"],
+        choropleth_default_classification="v1_1a",
+        dot_density_default_classification="v1_3a"
+    )]
+
+    # WHEN we invoke filter_content against our test values
+    returned_topics = filter_content(test_spec_rows, [test_topic])
+
+    # THEN we expect to get a single topic and variable back
+    assert len(returned_topics) == 1
+    returned_variables = returned_topics[0].variables
+    assert len(returned_variables) == 1
+    returned_variable = returned_variables[0]
+    # AND we expect the variable to have three classifications
+    returned_classifications = returned_variable.classifications
+    assert len(returned_classifications) == 3
+    # AND we expect there to be one choropleth default classification, and it to be v1_1a
+    choropleth_default_classifications = [c for c in returned_classifications if c.choropleth_default is True]
+    assert len(choropleth_default_classifications) == 1
+    assert choropleth_default_classifications[0].code == "v1_1a"
+    # AND we expect there to be one dot density default classification, and it to be v1_3a
+    dot_density_default_classifications = [c for c in returned_classifications if c.dot_density_default is True]
+    assert len(dot_density_default_classifications) == 1
+    assert dot_density_default_classifications[0].code == "v1_3a"
+
+
+def test_filter_content_adds_2011_comparison_flags():
+    # GIVEN a CensusTopic that has two CensusVariables with three CensusClassifications
+    test_topic = get_test_topic()
+    test_variable_1 = get_test_variable(code="v1")
+    test_classifications_1 = [
+        get_test_classification(code="v1_1a"),
+        get_test_classification(code="v1_2a"),
+        get_test_classification(code="v1_3a")
+    ]
+    test_variable_1.classifications = test_classifications_1
+    test_variable_2 = get_test_variable(code="v2")
+    test_classifications_2 = [
+        get_test_classification(code="v2_1a"),
+        get_test_classification(code="v2_2a"),
+        get_test_classification(code="v2_3a")
+    ]
+    test_variable_2.classifications = test_classifications_2
+    test_topic.variables = [test_variable_1, test_variable_2]
+
+    # AND given a spec row that specifies all three classification for both, but only 2011 comparison data for one
+    test_spec_rows = [
+        get_test_spec_row(
+            dataset_classification="v1_1a",
+            additional_atlas_classifications=["v1_2a", "v1_3a"],
+            comparison_2011=True
+        ),
+        get_test_spec_row(
+            dataset_classification="v2_1a",
+            additional_atlas_classifications=["v2_2a", "v2_3a"]
+        )
+    ]
+
+    # WHEN we invoke filter_content against our test values
+    returned_topics = filter_content(test_spec_rows, [test_topic])
+
+    # THEN we expect to get a single topic and two variables back
+    assert len(returned_topics) == 1
+    returned_variables = returned_topics[0].variables
+    assert len(returned_variables) == 2
+
+    # AND we expect each variable to have three classifications
+    assert len(returned_variables[0].classifications) == 3
+    assert len(returned_variables[1].classifications) == 3
+    # AND we expect there to be 2011 comparison data flagged for all classifications in variable 1
+    assert all(c.comparison_2011_data_available for c in returned_variables[0].classifications)
+    # AND we expect there to be 2011 comparison data flagged for no classifications in variable 1
+    assert not any(c.comparison_2011_data_available for c in returned_variables[1].classifications)


### PR DESCRIPTION
commit d40b694a145fd3fdc2ae4d18a1be0eaa3da70c7c (HEAD -> feat/content-datasets, origin/feat/content-datasets)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Aug 26 15:01:08 2022 +0100

    fix tests for census_objects

    Add new CensusClassification properties to tests for content/census_objects.py

commit 5dde5b5cb573e2db5f1077e0955cd9cfcfa58bb6
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Aug 25 16:17:32 2022 +0100

    filter census content from rich content spec table

    - Add script, filter_content_json_to_rich_content_spec.py to content
    dir that filters a content.json file to only those classifications
    referenced for the atlas in a rich content spec file, downloaded
    from the confluence table, here:
    https://confluence.ons.gov.uk/display/ODADH/Rich+content+product+specifications

    - As the rich content spec deals with datasets as the main unit of
    publication, add dataset references (where known) to the content.jsons
