### PR TITLE
add tiles subpath to requests for data tiles

### DIFF
--- a/env/dev.sh
+++ b/env/dev.sh
@@ -3,7 +3,7 @@
 export SKADAPTER=""
 # allow override of these values with locally set ones
 if [ -z $VITE_GEODATA_BASE_URL]; then
-export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/quads"
+export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads"
 else
 export VITE_GEODATA_BASE_URL=$VITE_GEODATA_BASE_URL
 fi

--- a/env/netlify.sh
+++ b/env/netlify.sh
@@ -1,7 +1,7 @@
 # env vars needed to run on netlify
 
 export SKADAPTER=""
-export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/quads"
+export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads"
 export VITE_CONTENT_JSONS='[
     "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2011-new-format-content.json"
 ]'

--- a/env/sandbox.sh
+++ b/env/sandbox.sh
@@ -1,7 +1,7 @@
 # env vars needed to build for ONS sandbox env
 
 export SKADAPTER="node"
-export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/quads"
+export VITE_GEODATA_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads"
 export VITE_CONTENT_JSONS='[
     "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2011-new-format-content.json"
 ]'

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -33,7 +33,7 @@ export const fetchTileDataForBbox = async (args: { categoryCode: string; geoType
   fall within geographic bounding box represented by 'tile'.
 */
 export const fetchTileData = async (args: { categoryCode: string; geoType: GeoType; tile: DataTile }) => {
-  const url = `${geodataBaseUrl}/${args.geoType}/${args.tile.tilename}/${args.categoryCode}.csv`;
+  const url = `${geodataBaseUrl}/tiles/${args.geoType}/${args.tile.tilename}/${args.categoryCode}.csv`;
   const response = await fetch(url);
   const csv = await response.text();
   return dsv.csvParse(csv);


### PR DESCRIPTION
### What

commit 2ddc0f9383dbcbd58490524cb6a098c54e3e32f3 (HEAD -> feat/add-tiles-nesting-to-data-requests, origin/feat/add-tiles-nesting-to-data-requests)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Aug 31 09:23:58 2022 +0100

    add tiles subpath to requests for data tiles

    - change s3 base url to 'newquads' test data tile set
    - add new 'tiles' sub-path to requests for data tiles

### How to review

Road-test the netlify preview and see if anything is broken when getting files from the new S3 path.

### Who can review

Anyone