### PR TITLE
Feat/add topic groups

### DIFF
--- a/env/dev.sh
+++ b/env/dev.sh
@@ -10,7 +10,7 @@ fi
 
 if [ -z $VITE_CONTENT_JSONS]; then
 export VITE_CONTENT_JSONS='[
-    "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2011-new-format-content.json"
+    "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2011-TEST-PLACEHOLDER-VAR-DESCS-all-atlas-content-2022-09-02-11-58-45.json"
 ]'
 else
 export VITE_CONTENT_JSONS=$VITE_CONTENT_JSONS

--- a/src/helpers/topicHelpers.ts
+++ b/src/helpers/topicHelpers.ts
@@ -1,4 +1,42 @@
-import type { Topic, Variable, Classification, Category } from "../types";
+import type { TopicGroup, Topic, Variable, Classification } from "../types";
+
+
+/*
+  Iterate over list of TopicGroups and convert each to a topic by moving the variables in side each of their child
+  topics to a new key in the TopicGroup, then removing the topics themselves
+*/
+export const flattenTopicGroupsToTopics = (topicGroups: [TopicGroup]) => {
+  const topics = [];
+  for (const topicGroup of topicGroups) {
+    topics.push({
+      name: topicGroup.name,
+      slug: topicGroup.slug,
+      desc: topicGroup.desc,
+      variables: topicGroup.topics.flatMap((t) => t.variables),
+    })
+  }
+  return topics;
+};
+
+
+/*
+  Iterate over list of TopicGroups and merge topic groups with the same name.
+*/
+export const mergeTopicGroups = (topicGroups: [TopicGroup]) => {
+  const topicGroupNames = new Set(topicGroups.map((tg) => tg.name));
+  const mergedTopicGroups = [];
+  for (const topicGroupName of topicGroupNames) {
+    const topicGroupsToMerge = topicGroups.filter((tg) => tg.name === topicGroupName);
+    const allTopics = topicGroupsToMerge.flatMap((tg) => tg.topics);
+    mergedTopicGroups.push({
+      name: topicGroupsToMerge[0].name,
+      slug: topicGroupsToMerge[0].slug,
+      desc: topicGroupsToMerge[0].desc,
+      topics: mergeTopics(allTopics as [Topic]),
+    });
+  }
+  return mergedTopicGroups;
+};
 
 /*
   Iterate over list of Topics and merge topics with the same name.

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -1,5 +1,5 @@
 import { writable } from "svelte/store";
-import type { MapState, VizData, SelectedGeographyData, Topic } from "../types";
+import type { MapState, VizData, SelectedGeographyData, Topics } from "../types";
 
 /**
  * A Svelte store containing any map state we need to be aware of within the Svelte app.
@@ -24,4 +24,4 @@ export const preventFlyToGeographyStore = writable<string | undefined>(undefined
 /**
  * A Svelte store containing all topics
  */
-export const topicStore = writable<[Topic] | undefined>(undefined);
+export const topicStore = writable<[Topics] | undefined>(undefined);

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,12 +7,20 @@ export type MapState = {
   zoom: number;
 };
 
+export type TopicGroup = {
+  name: string;
+  slug: string;
+  desc: string;
+  topics: [Topic];
+};
+
 export type Topic = {
   name: string;
   slug: string;
   desc: string;
   variables: [Variable];
 };
+
 export type Variable = {
   name: string;
   slug: string;
@@ -21,6 +29,7 @@ export type Variable = {
   units: string;
   classifications: [Classification];
 };
+
 export type Classification = {
   code: string;
   slug: string;


### PR DESCRIPTION
### What

commit 800907839d8583de542123db572bd2cf3e0ee5e7 (HEAD -> feat/add-topic-groups, origin/feat/add-topic-groups)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Sep 2 13:36:25 2022 +0100

    refactor loading content.json to flatten TopicGroups to Topics on ingest

    topicHelpers functions for merging TopicGroups from multiple content.json
    and then flattening them to topics that keep the original basic properties
    (name, slug, desc) of their parent topic groupings, and merge the variables
    from all topics in the topic group.

### How to review

Read the code, run the tests, check the preview

### Who can review

Anyone