### PR TITLE
fix runtime-env ep calls from setContentStores on census-atlas basepath

### DIFF
--- a/src/data/setContentStores.ts
+++ b/src/data/setContentStores.ts
@@ -2,6 +2,7 @@ import { get } from "svelte/store";
 import { geodataBaseUrlStore, topicStore } from "../stores/stores";
 import { mergeTopics } from "../helpers/topicHelpers";
 import type { Topic } from "../types";
+import { appBasePath } from "../buildEnv";
 
 const fetchTopicsFromContentJsons = async (contentJsonUrls: [string]) => {
   const topics = await Promise.all(
@@ -36,7 +37,7 @@ export const setContentStoresOnce = async () => {
   if (get(topicStore)) {
     return;
   }
-  const env = await (await fetch("/runtime-env")).json();
+  const env = await (await fetch(`${appBasePath}/runtime-env`)).json();
   geodataBaseUrlStore.set(env.geodataBaseUrl);
   const topics = await fetchTopicsFromContentJsons(env.contentJsonUrls);
   const mergedTopics = mergeTopics(topics as [Topic]);

--- a/src/routes/runtime-env.ts
+++ b/src/routes/runtime-env.ts
@@ -1,7 +1,7 @@
 import type { RequestHandler } from "@sveltejs/kit";
 
 // return values from env set in runtime env (default to values set at build time if runtime env is missing var)
-export const get: RequestHandler = async ({ params }) => {
+export const get: RequestHandler = async () => {
   return {
     status: 200,
     body: {


### PR DESCRIPTION
fix runtime-env ep calls from setContentStores on census-atlas basepath

- Fix bug where setContentStores calls to runtime-env endpoint where not accounting for app base paths other than "".

- Remove reundant params arg from runtime-env endpoint request handler func.
