### PR TITLE
add content.ts keys for staging and prod

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -22,4 +22,6 @@ export default {
       contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads",
     },
   ],
+  staging: [],
+  prod: [],
 };


### PR DESCRIPTION
### What

add (empty) entries for `staging` and `prod` environments to content.ts. This change needed to deploy the atlas to these environments and have it display the service unavailable page.

### How to review

read the code

### Who can review

Anyone