### PR TITLE
appBasePath -> /census/maps for ONS deployments

### DIFF
--- a/dp-census-atlas.nomad
+++ b/dp-census-atlas.nomad
@@ -49,7 +49,7 @@ job "dp-census-atlas" {
 
         check {
           type     = "http"
-          path     = "/census-atlas/health"
+          path     = "/census/maps/health"
           interval = "10s"
           timeout  = "2s"
         }

--- a/env/ons.sh
+++ b/env/ons.sh
@@ -1,5 +1,5 @@
 # env vars needed to build for ONS envs
 
 export SKADAPTER="node"
-export VITE_APP_BASE_PATH="/census-atlas"
+export VITE_APP_BASE_PATH="/census/maps"
 export VITE_GEO_BASE_URL="https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads/geo"

--- a/workaround-sveltekit-3726.sh
+++ b/workaround-sveltekit-3726.sh
@@ -1,16 +1,21 @@
 #!/usr/bin/env bash
 
+# remove leading slash from APP_BASE_PATH if present
+APP_BASE_PATH=${VITE_APP_BASE_PATH:-"census-atlas"}
+APP_BASE_PATH_NO_LEADING_SLASH=${APP_BASE_PATH#/}
+
 echo "Workaround Sveltekit issue 3726..."
 # https://github.com/sveltejs/kit/issues/3726
+echo "Re-rooting app to base path ${APP_BASE_PATH_NO_LEADING_SLASH}"
 
 pushd ./build/client
-mkdir census-atlas
-mv _app census-atlas/_app
+    mkdir -p "$APP_BASE_PATH_NO_LEADING_SLASH"
+    mv _app "$APP_BASE_PATH_NO_LEADING_SLASH"/_app
 popd
 
 pushd ./build/static
-# mv ignores .hidden objects (so don't move the destination dir into itself)
-mkdir .census-atlas
-mv * .census-atlas
-mv .census-atlas census-atlas
+    # mv ignores .hidden objects (so don't move the destination dir into itself)
+    mkdir -p ."$APP_BASE_PATH_NO_LEADING_SLASH"
+    mv * ."$APP_BASE_PATH_NO_LEADING_SLASH"
+    mv ."$APP_BASE_PATH_NO_LEADING_SLASH" "$APP_BASE_PATH_NO_LEADING_SLASH"
 popd


### PR DESCRIPTION
NB not to merge until related front-end router changes are made! (https://github.com/ONSdigital/dp-frontend-router/pull/346)

### What

commit 04d5bd12495150418dc545c941cc8d5f20d49beb (HEAD -> feat/new-basepath-maps/census, origin/feat/new-basepath-maps/census)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Sep 16 09:41:25 2022 +0100

    parameterise app base path in workaround-sveltekit-3726.sh

commit 85f48ae577fc97a7cec05009d72d719047bc1e75
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Sep 16 08:40:21 2022 +0100

    appBasePath -> /census/maps for ONS deployments

### How to review

read the changes

### Who can review

Anyone