### PR TITLE
Feat/fake data banner

### DIFF
--- a/src/components/AppLayout.svelte
+++ b/src/components/AppLayout.svelte
@@ -1,13 +1,18 @@
 <script>
-  import Header from "./Header.svelte";
+  import FakeDataHeader from "./FakeDataHeader.svelte";
+  import Header from "./FakeDataHeader.svelte";
   import Map from "./Map.svelte";
   import MapTips from "./MapTips.svelte";
   import MapLegend from "./MapLegend.svelte";
-  import { appParamsStore } from "../stores/stores";
+  import { appParamsStore, contentStore } from "../stores/stores";
 </script>
 
 <div class="inset-0 lg:absolute lg:flex flex-col text-onsblack">
-  <Header />
+  {#if $contentStore.fakeDataLoaded}
+    <FakeDataHeader />
+  {:else}
+    <Header />
+  {/if}
   <div class="flex-1 flex flex-col-reverse lg:flex-row overflow-y-auto ">
     <div class="flex-1 grow-[4] min-w-[30rem] max-w-[35rem] overflow-y-auto" class:hidden={$appParamsStore.embed}>
       <slot />

--- a/src/components/FakeDataHeader.svelte
+++ b/src/components/FakeDataHeader.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { buildHyperlink } from "../helpers/buildHyperlinkHelper";
+  import { page } from "$app/stores";
+  import Logo from "./icons/Logo.svelte";
+  import Census2021 from "./icons/Census2021.svelte";
+</script>
+
+<header class="flex items-center gap-1 h-[46px] p-2 px-5 border-b-[1px] border-b-ons-grey-15 bg-red-500">
+  <div class="">
+    <a href={buildHyperlink($page.url)} class="custom-ring">
+      <Logo />
+    </a>
+  </div>
+  <div class="fill-ons-census p-3">
+    <Census2021 />
+  </div>
+  <strong class="text-white">WARNING! This is a prototype. Data is synthetic. It is NOT actual 2021 Census data.</strong>
+</header>

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -5,21 +5,21 @@ export default {
     {
       contentJsonUrl:
         "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads/2011-all-topics-with-variable-groups.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads",
+      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011",
     },
   ],
   netlify: [
     {
       contentJsonUrl:
         "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads/2011-all-topics-with-variable-groups.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads",
+      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011",
     },
   ],
   sandbox: [
     {
       contentJsonUrl:
         "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads/2011-all-topics-with-variable-groups.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/newquads",
+      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011",
     },
   ],
   staging: [],

--- a/src/data/setContentStore.ts
+++ b/src/data/setContentStore.ts
@@ -57,6 +57,16 @@ export const setContentStoreOnce = async () => {
   // extract all successfully loaded releases
   const releases = rawContent.map((ct) => ct.contentJson.meta.release);
 
+  // get fakeDataLoaded flag
+  let fakeDataLoaded = false;
+  const fakeDataUrlComponent = "/FAKE";
+  for (const ct of rawContent) {
+    if (ct.contentConfig.contentBaseUrl.includes(fakeDataUrlComponent)) {
+      fakeDataLoaded = true;
+      break;
+    }
+  }
+
   // merge variableGroups
   const allVariableGroups = rawContent.flatMap((ct) => ct.contentJson.content);
   const mergedVariableGroups = mergeVariableGroups(allVariableGroups as VariableGroup[]);
@@ -65,5 +75,6 @@ export const setContentStoreOnce = async () => {
   contentStore.set({
     releases: releases,
     variableGroups: mergedVariableGroups as VariableGroup[],
+    fakeDataLoaded: fakeDataLoaded,
   } as ContentTree);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,7 @@ export type ContentConfig = {
 export type ContentTree = {
   releases: string[];
   variableGroups: VariableGroup[];
+  fakeDataLoaded: boolean;
 };
 
 export type AppParams = {


### PR DESCRIPTION
commit 852629f0e6656332726eb911a9931c6b6c0c2b55 (HEAD -> feat/fake-data-banner, origin/feat/fake-data-banner)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Sep 29 17:25:42 2022 +0100

    fake data banner + 2011 data indicated as fake

    - Add fake data banner to be displayed instead of normal banner
    if any contentBaseUrls for data loaded for env (in content.ts)
    included the string '/FAKE' as part of their url.
    - Change contentBaseUrl for all 2011 data referenced in content.ts
    to new URL with /FAKE as part of it (while this is real 2011 data,
    the UI presents it as 2021 data, and so it needs to be labelled as
    fake)

## HOW TO REVIEW

- Go to netlify preview (see below) and check it is showing the fake data banner
- read the code