### PR TITLE
local port 28100 to avoid clashes with other ONS apps

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,10 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import type { UserConfig } from 'vite';
 
 const config: UserConfig = {
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	server: {
+		port: 28100
+	}
 };
 
 export default config;


### PR DESCRIPTION
commit 61bb2eeb6fe09c062e84b6b964621b0282f0c5f2 (HEAD -> feat/revert-local-port-to-28100, origin/feat/revert-local-port-to-28100)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Oct 6 08:43:27 2022 +0100

    local port 28100 to avoid clashes with other ONS apps