### PR TITLE
Feat/0.1% max precision in UI

### DIFF
--- a/src/components/BreaksChart.svelte
+++ b/src/components/BreaksChart.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-  import { ratioToPercentage } from "../util/numberUtil";
+  import { ratioToRoundedPercentageString } from "../helpers/ratioHelpers";
 
   export let hovered = null;
   export let selected = null;
   export let lineWidth = 3;
   export let breaks = [0, 20, 40, 60, 80, 100];
-  export let decimalPlaces = 0
   export let colors = ["rgba(234,236,177)", "rgba(169,216,145)", "rgba(0,167,186)", "rgba(0,78,166)", "rgba(0,13,84)"];
   export let suffix = "";
   export let snapTicks = true;
@@ -34,12 +33,12 @@
       class="tick"
       style="left: {i * (100 / (breaks.length - 1))}%; transform: translateX({i == 0 && snapTicks ? '-2px' : '-50%'});"
     >
-      {ratioToPercentage(breaks[i], decimalPlaces)}<span class="tick-suffix">{suffix}</span>
+      {ratioToRoundedPercentageString(breaks[i])}<span class="tick-suffix">{suffix}</span>
     </div>
   {/each}
   <div class="line" style="right: 0;" />
   <div class="tick" style="right: 0; transform: translateX({snapTicks ? '2px' : '50%'});">
-    {ratioToPercentage(breaks[breaks.length - 1], decimalPlaces)}<span class="tick-suffix">{suffix}</span>
+    {ratioToRoundedPercentageString(breaks[breaks.length - 1])}<span class="tick-suffix">{suffix}</span>
   </div>
   {#if selected}
     <!-- <div class="marker" style="width: 4px; left: calc({pos(selected, breaks)}% - {lineWidth / 2}px);" /> -->

--- a/src/components/MapLegend.svelte
+++ b/src/components/MapLegend.svelte
@@ -3,9 +3,9 @@
   import { vizStore, selectedGeographyStore } from "../stores/stores";
   import { contentStore } from "../stores/stores";
   import { formatTemplateString } from "../helpers/categoryHelpers";
-  import { ratioToPercentage } from "../util/numberUtil";
   import { choroplethColours } from "../helpers/choroplethHelpers";
   import { getDefaultChoroplethClassification } from "../helpers/variableHelpers";
+  import { ratioToRoundedPercentageString } from "../helpers/ratioHelpers"
 
   import BreaksChart from "./BreaksChart.svelte";
 
@@ -22,7 +22,6 @@
   $: categorySlug = params.category;
   $: category = variable ? defaultChoroplethClassification.categories.find((c) => c.slug === categorySlug) : undefined;
   $: breaks = $vizStore ? [$vizStore?.minMaxVals[0], ...$vizStore.breaks] : undefined
-  $: decimalPlaces = 1
 </script>
 
 <!-- todo: new design for all four states -->
@@ -38,7 +37,7 @@
         <!-- big percantage -->
         {#if category && categoryValueForSelectedGeography}
           <div class="whitespace-nowrap">
-            <span class="text-5xl font-bold"> {ratioToPercentage(categoryValueForSelectedGeography, decimalPlaces)}</span><span
+            <span class="text-5xl font-bold"> {ratioToRoundedPercentageString(categoryValueForSelectedGeography)}</span><span
               class="text-4xl font-bold">%</span
             >
           </div>
@@ -69,7 +68,6 @@
           selected={categoryValueForSelectedGeography}
           suffix="%"
           breaks={breaks}
-          decimalPlaces = {decimalPlaces}
           colors={choroplethColours}
         />
       {/if}

--- a/src/components/MapLegend.svelte
+++ b/src/components/MapLegend.svelte
@@ -3,7 +3,7 @@
   import { vizStore, selectedGeographyStore } from "../stores/stores";
   import { contentStore } from "../stores/stores";
   import { formatTemplateString } from "../helpers/categoryHelpers";
-  import { minDecimalPlacesToAntialias, ratioToPercentage } from "../util/numberUtil";
+  import { ratioToPercentage } from "../util/numberUtil";
   import { choroplethColours } from "../helpers/choroplethHelpers";
   import { getDefaultChoroplethClassification } from "../helpers/variableHelpers";
 
@@ -22,7 +22,7 @@
   $: categorySlug = params.category;
   $: category = variable ? defaultChoroplethClassification.categories.find((c) => c.slug === categorySlug) : undefined;
   $: breaks = $vizStore ? [$vizStore?.minMaxVals[0], ...$vizStore.breaks] : undefined
-  $: decimalPlaces = breaks ? minDecimalPlacesToAntialias(breaks) : 0
+  $: decimalPlaces = 1
 </script>
 
 <!-- todo: new design for all four states -->
@@ -38,7 +38,7 @@
         <!-- big percantage -->
         {#if category && categoryValueForSelectedGeography}
           <div class="whitespace-nowrap">
-            <span class="text-5xl font-bold"> {ratioToPercentage(categoryValueForSelectedGeography, 1)}</span><span
+            <span class="text-5xl font-bold"> {ratioToPercentage(categoryValueForSelectedGeography, decimalPlaces)}</span><span
               class="text-4xl font-bold">%</span
             >
           </div>

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -2,8 +2,7 @@ import * as dsv from "d3-dsv"; // https://github.com/d3/d3/issues/3469
 import type { Bbox, Category, DataTile, GeoType } from "src/types";
 import { bboxToDataTiles, englandAndWales } from "../helpers/spatialHelper";
 import { geoBaseUrl } from "../buildEnv";
-import { roundNumber, uniqueRoundedNumbers } from "../util/numberUtil";
-
+import { uniqueRoundedBreaks, roundedRatio } from "../helpers/ratioHelpers";
 /*
   Fetch place data files for all data 'tiles' (predefined coordinate grid squares) that intersect with current viewport 
   bounding box.
@@ -68,18 +67,14 @@ export const fetchBreaks = async (args: {
     }
     ToDo - refactor json files to match required format (see function output defintions above)
   */
-  // NB - use 3 decimal places in ratios for 0.1 percent precision
-  const decimalPlaces = 3;
   const breaks = Object.fromEntries(
-    Object.keys(breaksRaw).map((code) => [
-      code, 
-      uniqueRoundedNumbers({numbers: breaksRaw[code][args.geoType.toUpperCase()], decimalPlaces: decimalPlaces})
+    Object.keys(breaksRaw).map((code) => [code, uniqueRoundedBreaks(breaksRaw[code][args.geoType.toUpperCase()])
     ]),
   );
   const minMax = Object.fromEntries(
     Object.keys(breaksRaw).map((code) => [
       code, 
-      breaksRaw[code][`${args.geoType.toUpperCase()}_min_max`].map((n) => roundNumber({number: n, decimalPlaces: decimalPlaces}))
+      breaksRaw[code][`${args.geoType.toUpperCase()}_min_max`].map((n) => roundedRatio(n))
     ]),
   );
   console.log(breaksRaw)

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -2,6 +2,7 @@ import * as dsv from "d3-dsv"; // https://github.com/d3/d3/issues/3469
 import type { Bbox, Category, DataTile, GeoType } from "src/types";
 import { bboxToDataTiles, englandAndWales } from "../helpers/spatialHelper";
 import { geoBaseUrl } from "../buildEnv";
+import { roundNumber, uniqueRoundedNumbers } from "../util/numberUtil";
 
 /*
   Fetch place data files for all data 'tiles' (predefined coordinate grid squares) that intersect with current viewport 
@@ -67,12 +68,22 @@ export const fetchBreaks = async (args: {
     }
     ToDo - refactor json files to match required format (see function output defintions above)
   */
+  // NB - use 3 decimal places in ratios for 0.1 percent precision
+  const decimalPlaces = 3;
   const breaks = Object.fromEntries(
-    Object.keys(breaksRaw).map((code) => [code, breaksRaw[code][args.geoType.toUpperCase()]]),
+    Object.keys(breaksRaw).map((code) => [
+      code, 
+      uniqueRoundedNumbers({numbers: breaksRaw[code][args.geoType.toUpperCase()], decimalPlaces: decimalPlaces})
+    ]),
   );
   const minMax = Object.fromEntries(
-    Object.keys(breaksRaw).map((code) => [code, breaksRaw[code][`${args.geoType.toUpperCase()}_min_max`]]),
+    Object.keys(breaksRaw).map((code) => [
+      code, 
+      breaksRaw[code][`${args.geoType.toUpperCase()}_min_max`].map((n) => roundNumber({number: n, decimalPlaces: decimalPlaces}))
+    ]),
   );
+  console.log(breaksRaw)
+  console.log(breaks)
   return { breaks, minMax };
 };
 

--- a/src/helpers/ratioHelpers.ts
+++ b/src/helpers/ratioHelpers.ts
@@ -1,0 +1,16 @@
+import { ratioToPercentage, roundNumber, uniqueRoundedNumbers } from "../util/numberUtil"
+
+const percentageDecimalPlaces = 1;
+const ratioDecimalPlaces =  percentageDecimalPlaces * 3;
+
+export function ratioToRoundedPercentageString(r: number): string {
+    return ratioToPercentage(r, percentageDecimalPlaces)
+}
+
+export function uniqueRoundedBreaks(breaks: number[]): number[] {
+    return uniqueRoundedNumbers({numbers: breaks, decimalPlaces: ratioDecimalPlaces})
+}
+
+export function roundedRatio(r: number): number {
+    return roundNumber({number: r, decimalPlaces: ratioDecimalPlaces})
+}

--- a/src/util/numberUtil.ts
+++ b/src/util/numberUtil.ts
@@ -27,15 +27,22 @@ export function ratioToPercentage(r: number, decimalPlaces?: number): string {
 }
 
 /*
-  Return minimum decimal places needed to round ratios while ensuring they remain unique
+  Round number to decimalPlaces
 */
-export function minDecimalPlacesToAntialias(ratios: number[]): number {
-  let decimalPlaces = 0;
-  let percentages = ratios.map((n) => ratioToPercentage(n, decimalPlaces));
-  // iterate decimalPlaces until percentages contains only unique values
-  while (new Set(percentages).size != ratios.length) {
-    decimalPlaces += 1;
-    percentages = ratios.map((n) => ratioToPercentage(n, decimalPlaces));
-  }
-  return decimalPlaces;
+export function roundNumber(args: {number: number, decimalPlaces: number}): number {
+  const roundingFactor = 10 ** args.decimalPlaces;
+  return Math.round(args.number * roundingFactor) / roundingFactor;
+}
+
+/*
+  Return numbers rounded to decimalPlaces with repeated numbers removed.
+*/
+export function uniqueRoundedNumbers(args: {numbers: number[], decimalPlaces: number}): number[] {
+  return [
+    ...new Set(
+      args.numbers.map((n) => {
+        return roundNumber({number:n, decimalPlaces:args.decimalPlaces});
+      })
+    )
+  ];
 }

--- a/src/util/numberUtils.ts.test.ts
+++ b/src/util/numberUtils.ts.test.ts
@@ -1,0 +1,26 @@
+import { uniqueRoundedNumbers } from "./numberUtil";
+
+describe("uniqueRoundedNumbers", () => {
+  test("returns rounded original numbers if they differ by more than supplied decimal places", () => {
+    [
+      { testArgs: { numbers: [1, 2, 3, 4, 5], decimalPlaces: 1 }, expected: [1, 2, 3, 4, 5] },
+      { testArgs: { numbers: [1.1, 2.2, 3.3, 4.4, 5.5], decimalPlaces: 1 }, expected: [1.1, 2.2, 3.3, 4.4, 5.5] },
+      {
+        testArgs: { numbers: [1.101, 2.202, 3.303, 4.404, 5.505], decimalPlaces: 1 },
+        expected: [1.1, 2.2, 3.3, 4.4, 5.5],
+      },
+      { testArgs: { numbers: [1], decimalPlaces: 1 }, expected: [1] },
+    ].forEach((testVals) => {
+      expect(uniqueRoundedNumbers(testVals.testArgs)).toEqual(testVals.expected);
+    });
+  });
+  test("returns unique rounded original numbers only if they differ by less than supplied decimal places", () => {
+    [
+      { testArgs: { numbers: [1, 1, 1, 4, 5], decimalPlaces: 1 }, expected: [1, 4, 5] },
+      { testArgs: { numbers: [2.2, 2.2, 3.3, 4.4, 5.5], decimalPlaces: 1 }, expected: [2.2, 3.3, 4.4, 5.5] },
+      { testArgs: { numbers: [1.101, 2.202, 3.303, 4.404, 4.404], decimalPlaces: 1 }, expected: [1.1, 2.2, 3.3, 4.4] },
+    ].forEach((testVals) => {
+      expect(uniqueRoundedNumbers(testVals.testArgs)).toEqual(testVals.expected);
+    });
+  });
+});


### PR DESCRIPTION
commit 35e8c36a5c9a06850aaac86c6712b1ddf2a491ef (HEAD -> feat/0.1%-max-precision-in-ui, origin/feat/0.1%-max-precision-in-ui)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Oct 7 11:27:32 2022 +0100

    add ratioHelpers as source-of-truth for rounding ratios

    - ratioHelpers.ts exports functions that round ratios and percentages
    to a configurable number of decimal places for display. This avoids
    having the number of decimal places set in several different places.

    - api.ts, BreaksChart.svelte and MapLegend.svetle refactored to
    use functions from ratioHelpers.ts

commit 87885a0e3281ad45181e0270e69e4047ebc8d9ce
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Oct 7 11:09:39 2022 +0100

    round breaks to 3 decimal places (=1 % decimal place) and remove duplicates

    - numberUtil.uniqueRoundedNumbers called on breaks to round down to 3 decimal
    places (the equivalent of one decimal place once the ratios are transformed
    into percentages) and remove any non-unique numbers that result from rounding
    (.e.g 0.9232 and 0.9234 would be the same when rounded to 3 decimal places)

    - numberUtil.roundNumber rounded float to set number of decimal places

    - These both called from api.ts to round breaks to 0.1 percentage point
    (service-wide convention) and remove any duplicates that arise from that.