### PR TITLE
Feature/content json from florence

### DIFF
--- a/scripts/content/2021-content-spec.json
+++ b/scripts/content/2021-content-spec.json
@@ -1,0 +1,9 @@
+{
+    "cantabular_metadata_dir": "ar2776-c21ew_metadata-v1-3_cantab_20221011-22",
+    "variable_groups_spec_file": "Atlas_variable_groups.json",
+    "rich_content_spec_file": "Rich_content_product_specifications.csv",
+    "category_legend_strs_file": "Atlas_legend_strings.csv",
+    "variable_descriptions_file": "Atlas_variables_short_descriptions.csv",
+    "variable_geotype_availability_file": "Available_geotypes_for_classifications.csv",
+    "version": "2021"
+}

--- a/scripts/content/output_content_jsons/release-0.json
+++ b/scripts/content/output_content_jsons/release-0.json
@@ -1,0 +1,6 @@
+{ 
+  "meta": {
+    "release": "release-0"
+  },
+  "content": []
+}

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -1,162 +1,117 @@
 // A list of env-specific content.json file URLS
+const fakeCensus2021 = {
+  zero: {
+    contentJsonUrl: "https://dp.aws.onsdigital.uk/visualisations/dvc691/release-0.json",
+    contentBaseUrl: "",
+  },
+  dem:  {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-DEM.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+  edu: {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-EDU.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+  eilr: {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-EILR.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+  hou: {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-HOU.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+  huc: {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-HUC.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+  lab: {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-LAB.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+  mig: {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-MIG.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+  sogi: {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-SOGI.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+  ttw: {
+    contentJsonUrl:
+      "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021-v2/2021-v2-TTW.json",
+    contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
+  },
+}
+
+const fakeCensus2021preview = {
+  zero: {
+    contentJsonUrl: "https://publishing.dp.aws.onsdigital.uk/visualisations/dvc691/release-0.json",
+    contentBaseUrl: "",
+  },
+}
 
 export default {
-  dev: [
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-DEM.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-EDU.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-EILR.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-HOU.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-HUC.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-LAB.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-LAB.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-MIG.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-SOGI.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-TTW.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-  ],
-  netlify: [
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-DEM.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-EDU.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-EILR.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-HOU.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-HUC.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-LAB.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-LAB.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-MIG.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-SOGI.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-TTW.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-  ],
-  sandbox: [
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-DEM.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-EDU.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-EILR.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-HOU.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-HUC.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-LAB.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-LAB.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-MIG.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-SOGI.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-    {
-      contentJsonUrl:
-        "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-TTW.json",
-      contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2021",
-    },
-  ],
+  dev: {
+    web: [
+      fakeCensus2021.dem,
+      fakeCensus2021.edu,
+      fakeCensus2021.eilr,
+      fakeCensus2021.hou,
+      fakeCensus2021.huc,
+      fakeCensus2021.lab,
+      fakeCensus2021.mig,
+      fakeCensus2021.sogi,
+      fakeCensus2021.ttw,
+    ],
+    publishing:[]
+  },
+  netlify: {
+    web: [
+      fakeCensus2021.dem,
+      fakeCensus2021.edu,
+      fakeCensus2021.eilr,
+      fakeCensus2021.hou,
+      fakeCensus2021.huc,
+      fakeCensus2021.lab,
+      fakeCensus2021.mig,
+      fakeCensus2021.sogi,
+      fakeCensus2021.ttw,
+    ],
+    publishing: []
+  },
+  sandbox: {
+    web: [
+      fakeCensus2021.dem,
+      fakeCensus2021.edu,
+      fakeCensus2021.eilr,
+      fakeCensus2021.hou,
+      fakeCensus2021.huc,
+      fakeCensus2021.lab,
+      fakeCensus2021.mig,
+      fakeCensus2021.sogi,
+      fakeCensus2021.ttw,
+    ],
+    publishing:[
+      fakeCensus2021preview.zero,
+      fakeCensus2021.dem,
+      fakeCensus2021.edu,
+      fakeCensus2021.eilr,
+      fakeCensus2021.hou,
+      fakeCensus2021.huc,
+      fakeCensus2021.lab,
+      fakeCensus2021.mig,
+      fakeCensus2021.sogi,
+      fakeCensus2021.ttw,
+    ],
+  },
   staging: [],
   prod: [],
 };

--- a/src/data/setContentStore.ts
+++ b/src/data/setContentStore.ts
@@ -11,24 +11,32 @@ import type { ContentConfig, ContentTree, VariableGroup } from "../types";
   with the loaded content.json.
 */
 const fetchContent = async () => {
+  // get content for current env and mode (publishing or web)
   const runtimeEnv = await (await fetch(`${appBasePath}/api/runtime-env`)).json();
-  const contentForEnv = content[runtimeEnv.envName];
+  const envMode = runtimeEnv.isPublishing ? "publishing" : "web";
+  const contentForEnvAndMode = content[runtimeEnv.envName][envMode];
+  // fetch content
   const rawContent = await Promise.all(
-    contentForEnv.map(async (ctcfg) => {
-      const resp = await fetch(ctcfg.contentJsonUrl);
-      if (resp.status != 200) {
-        console.log(`Content json file ${ctcfg.contentJsonUr} could not be fetched.`);
-        return null;
-      } else {
-        try {
+    contentForEnvAndMode.map(async (ctcfg) => {
+      try {
+        const resp = await fetch(ctcfg.contentJsonUrl);
+        if (resp.status != 200) {
+          console.log(`Content json file ${ctcfg.contentJsonUrl} could not be fetched.`);
+          return null;
+        } else {
           const contentJson = await resp.json();
-          return {
-            contentConfig: ctcfg,
-            contentJson: contentJson,
-          };
-        } catch (e) {
-          console.log(`Content json file ${ctcfg.contentJsonUr} could not be parsed: ${e}`);
+          if (typeof contentJson === "string") {
+            console.log(`Content json file ${ctcfg.contentJsonUrl} could not be fetched: ${contentJson}.`);
+            return null
+          } else {
+            return {
+              contentConfig: ctcfg,
+              contentJson: contentJson,
+            };
+          }
         }
+      } catch (e) {
+        console.log(`Error fetching / parsing content json file ${ctcfg.contentJsonUrl}: ${e}`);
       }
     }),
   ).then((responseArry) => {

--- a/src/routes/api/runtime-env/+server.ts
+++ b/src/routes/api/runtime-env/+server.ts
@@ -2,5 +2,8 @@ import { json, type RequestHandler } from "@sveltejs/kit";
 
 // return values from env set in runtime env (default to values set at build time if runtime env is missing var)
 export const GET: RequestHandler = () => {
-  return json({ envName: process.env["ENV_NAME"] || import.meta.env.VITE_ENV_NAME });
+  return json({
+    envName: process.env["ENV_NAME"] || import.meta.env.VITE_ENV_NAME,
+    isPublishing: (process.env["IS_PUBLISHING"] || "false").toLowerCase() === "true",
+  });
 };


### PR DESCRIPTION
### What

commit d90002a2f626808de7a6f6069ef0960b9542a635 (HEAD -> feature/content-json-from-florence, origin/feature/content-json-from-florence, origin/feat/content-json-from-florence, feat/content-json-from-florence)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Oct 20 14:33:55 2022 +0100

    add release zero content json

commit cc7475dc83b84c00b21e2c7d21f48a5ba2cf951c
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Oct 20 14:30:47 2022 +0100

    alter loaded content based on IS_PUBLISHING env var

    - Add IS_PUBLISHING to set of env vars that runtime-env endpoint
    is aware of
    - add 'web' and 'publishing' keys to content.ts with different
    subsets of content to load (also DRY up a bit by defining
    content in seperate object to be referenced in env-specific lists)
    - change setContentStore behaviour to load different content based
    on both runtimeEnv.envName and runtimeEnv.isPublishing flags.

commit aff7b616fdbb2e864f63c13fc0581485cb23c863
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Oct 20 14:29:10 2022 +0100

    add mistakenly un-checked-in 2021-content-spec.json

### How to review

hard to test as it relies on being IN a publishing env to work properly, but can be simulated locally with `IS_PUBLISHING=true npm run dev`, which will load the dev:publishing set of content (which is empty, so you will see the service unavailable page)

### Who can review

Anyone