### PR TITLE
add -f force flag, don't create empty data tile files

### DIFF
--- a/scripts/mktiles/cmd/mktiles/main.go
+++ b/scripts/mktiles/cmd/mktiles/main.go
@@ -33,14 +33,16 @@ func main() {
 	outdir := flag.String("O", "./out/", "directory to hold output files (must be empty)")
 	doRatios := flag.Bool("R", false, "calculate ratios (eg 2011 data)")
 	doFake := flag.Bool("F", false, "generate fake metrics")
+	force := flag.Bool("f", false, "force using an existing out directory")
 	flag.Parse()
 
 	log.Printf("            input dir: %s", *indir)
 	log.Printf("           output dir: %s", *outdir)
 	log.Printf("          calc ratios: %t", *doRatios)
 	log.Printf("generate fake metrics: %t", *doFake)
+	log.Printf("                force: %t", *force)
 
-	if err := setupOutDir(*outdir); err != nil {
+	if err := setupOutDir(*outdir, *force); err != nil {
 		log.Fatal(err)
 	}
 
@@ -110,9 +112,12 @@ func main() {
 	}
 }
 
-func setupOutDir(dir string) error {
+func setupOutDir(dir string, force bool) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
+	}
+	if force {
+		return nil
 	}
 
 	f, err := os.Open(dir)

--- a/scripts/mktiles/metric/tiles.go
+++ b/scripts/mktiles/metric/tiles.go
@@ -9,34 +9,31 @@ import (
 	"github.com/ONSdigital/dp-census-atlas/scripts/mktiles/types"
 )
 
-// Temporarily emulate previous version by not including category in header
-// when there are no data lines.
-// Simplify when we don't use the old version any more.
-
 // MakeTiles creates data tile CSVs in dir.
 func (m *M) MakeTiles(geos []types.Geocode, dir string) error {
 	for _, cat := range m.cats {
 		records := [][]string{
-			{"geography_code"},
-			//{"geography_code", string(cat)},
+			{"geography_code", string(cat)},
 		}
 
 		found := false
 		for _, geo := range geos {
 			val, ok := m.tab[cat][geo]
 			if !ok {
-				log.Printf("%s %s: value not found", cat, geo)
 				continue
 			}
 			cell := strconv.FormatFloat(float64(val), 'g', 13, 64)
 			records = append(records, []string{string(geo), cell})
 			found = true
 		}
-		if found {
-			records[0] = append(records[0], string(cat))
+
+		fname := filepath.Join(dir, string(cat)+".csv")
+		if !found {
+			log.Printf("%s: no matching geos; not creating", fname)
+			continue
 		}
 
-		err := files.SaveCSV(filepath.Join(dir, string(cat)+".csv"), records)
+		err := files.SaveCSV(fname, records)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What

Add a -f flag to force using an existing non-empty output directory.
Skip creating a data tile if it is empty; ie there are no geography lines.
Remove the 'value not found' messages since these were related to empty data tiles.

### How to review

cd scripts/mktiles
go build ./cmd/mktiles/...

and try it on some data
