### PR TITLE
replace ratioHelpers with percentageHelpers as prod data in %

### DIFF
--- a/src/components/BreaksChart.svelte
+++ b/src/components/BreaksChart.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ratioToRoundedPercentageString } from "../helpers/ratioHelpers";
+  import { dataToRoundedString } from "../helpers/percentageHelpers";
 
   export let hovered = null;
   export let selected = null;
@@ -31,12 +31,12 @@
       class="tick"
       style="left: {i * (100 / (breaks.length - 1))}%; transform: translateX({i == 0 && snapTicks ? '-2px' : '-50%'});"
     >
-      {ratioToRoundedPercentageString(breaks[i])}<span class="tick-suffix">{suffix}</span>
+      {dataToRoundedString(breaks[i])}<span class="tick-suffix">{suffix}</span>
     </div>
   {/each}
   <div class="line" style="right: 0;" />
   <div class="tick" style="right: 0; transform: translateX({snapTicks ? '2px' : '50%'});">
-    {ratioToRoundedPercentageString(breaks[breaks.length - 1])}<span class="tick-suffix">{suffix}</span>
+    {dataToRoundedString(breaks[breaks.length - 1])}<span class="tick-suffix">{suffix}</span>
   </div>
   {#if selected}
     <!-- <div class="marker" style="width: 4px; left: calc({pos(selected, breaks)}% - {lineWidth / 2}px);" /> -->

--- a/src/components/MapLegend.svelte
+++ b/src/components/MapLegend.svelte
@@ -4,7 +4,7 @@
   import { contentStore } from "../stores/stores";
   import { formatTemplateString } from "../helpers/categoryHelpers";
   import { choroplethColours } from "../helpers/choroplethHelpers";
-  import { ratioToRoundedPercentageString } from "../helpers/ratioHelpers";
+  import { dataToRoundedString } from "../helpers/percentageHelpers";
 
   import BreaksChart from "./BreaksChart.svelte";
   import GeoTypeBadge from "./GeoTypeBadge.svelte";
@@ -41,7 +41,7 @@
         <div class="flex gap-3 items-center">
           <div class="whitespace-nowrap">
             <span class="text-4xl md:text-5xl font-bold">
-              {ratioToRoundedPercentageString(categoryValueForSelectedGeography)}</span
+              {dataToRoundedString(categoryValueForSelectedGeography)}</span
             ><span class="text-3xl md:text-4xl font-bold">%</span>
           </div>
           <div class="flex-grow leading-[0px]">

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -1,7 +1,7 @@
 import * as dsv from "d3-dsv"; // https://github.com/d3/d3/issues/3469
 import type { Bbox, Category, DataTile, GeoType } from "src/types";
 import { bboxToDataTiles, englandAndWales } from "../helpers/spatialHelper";
-import { uniqueRoundedBreaks, roundedRatio } from "../helpers/ratioHelpers";
+import { uniqueRoundedBreaks, roundedData } from "../helpers/percentageHelpers";
 
 const geoBaseUrl = "https://cdn.ons.gov.uk/maptiles/cm-geos/v2";
 
@@ -75,7 +75,7 @@ export const fetchBreaks = async (args: {
   const minMax = Object.fromEntries(
     Object.keys(breaksRaw).map((code) => [
       code,
-      breaksRaw[code][`${args.geoType.toUpperCase()}_min_max`].map((n) => roundedRatio(n)),
+      breaksRaw[code][`${args.geoType.toUpperCase()}_min_max`].map((n) => roundedData(n)),
     ]),
   );
   return { breaks, minMax };

--- a/src/helpers/percentageHelpers.ts
+++ b/src/helpers/percentageHelpers.ts
@@ -1,0 +1,15 @@
+import { roundNumber, uniqueRoundedNumbers } from "../util/numberUtil"
+
+const percentageDecimalPlaces = 1;
+
+export function dataToRoundedString(r: number): string {
+    return r.toFixed(percentageDecimalPlaces)
+}
+
+export function uniqueRoundedBreaks(breaks: number[]): number[] {
+    return uniqueRoundedNumbers({numbers: breaks, decimalPlaces: percentageDecimalPlaces})
+}
+
+export function roundedData(r: number): number {
+    return roundNumber({number: r, decimalPlaces: percentageDecimalPlaces})
+}

--- a/src/helpers/ratioHelpers.ts
+++ b/src/helpers/ratioHelpers.ts
@@ -1,9 +1,10 @@
+// ToDo remove this deprecated module once fake data is in percentages!
 import { ratioToPercentage, roundNumber, uniqueRoundedNumbers } from "../util/numberUtil"
 
 const percentageDecimalPlaces = 1;
 const ratioDecimalPlaces =  percentageDecimalPlaces * 3;
 
-export function ratioToRoundedPercentageString(r: number): string {
+export function dataToRoundedString(r: number): string {
     return ratioToPercentage(r, percentageDecimalPlaces)
 }
 
@@ -11,6 +12,6 @@ export function uniqueRoundedBreaks(breaks: number[]): number[] {
     return uniqueRoundedNumbers({numbers: breaks, decimalPlaces: ratioDecimalPlaces})
 }
 
-export function roundedRatio(r: number): number {
+export function roundedData(r: number): number {
     return roundNumber({number: r, decimalPlaces: ratioDecimalPlaces})
 }


### PR DESCRIPTION
commit b9b9f0c5e5cc153617f5c3308e4bf6bd8a307a77 (HEAD -> feature/handle-ratio-and-percentage-data, origin/feature/handle-ratio-and-percentage-data)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Oct 24 14:52:03 2022 +0100

    replace ratioHelpers with percentageHelpers as prod data in %

    - new module percentageHelpers.ts does equivalent processing /
    rouding to ratioHelpers.ts but for % (i.e. one decimal place
    instead of three, don't mutltiply by 100 for display)
    - ratioHelpers.ts swapped out for percentageHelpers.ts throughout
    code (this is stopgap while fake data is still in ratios -
    ratioHelper can be swapped in locally to test out changes)
