### PR TITLE
add 2021 dry-run publishing content to sandbox in content.ts

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -6,6 +6,16 @@ const fakeCensus2021preview = {
     contentJsonUrl: "https://publishing.dp.aws.onsdigital.uk/visualisations/dvc691/release-0.json",
     contentBaseUrl: "",
   },
+  dem:  {
+    contentJsonUrl:
+      "https://publishing.dp.aws.onsdigital.uk/visualisations/dvc691/2021-DEM.json",
+    contentBaseUrl: "https://ons-dp-sandbox-census-maps-dem-mig.s3.eu-west-2.amazonaws.com/FAKE",
+  },
+  mig:  {
+    contentJsonUrl:
+      "https://publishing.dp.aws.onsdigital.uk/visualisations/dvc691/2021-MIG.json",
+    contentBaseUrl: "https://ons-dp-sandbox-census-maps-dem-mig.s3.eu-west-2.amazonaws.com/FAKE",
+  },
 }
 
 const fakeCensus2021 = {
@@ -13,6 +23,19 @@ const fakeCensus2021 = {
     contentJsonUrl: "https://dp.aws.onsdigital.uk/visualisations/dvc691/release-0.json",
     contentBaseUrl: "",
   },
+  dem:  {
+    contentJsonUrl:
+      "https://dp.aws.onsdigital.uk/visualisations/dvc691/2021-DEM.json",
+    contentBaseUrl: "https://ons-dp-sandbox-census-maps-dem-mig.s3.eu-west-2.amazonaws.com/FAKE",
+  },
+  mig:  {
+    contentJsonUrl:
+      "https://dp.aws.onsdigital.uk/visualisations/dvc691/2021-MIG.json",
+    contentBaseUrl: "https://ons-dp-sandbox-census-maps-dem-mig.s3.eu-west-2.amazonaws.com/FAKE",
+  },
+}
+
+const fakeCensus2021Public = {
   dem:  {
     contentJsonUrl:
       "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-DEM.json",
@@ -166,42 +189,29 @@ export default {
   // netlify
   netlify: {
     web: [
-      fakeCensus2021.dem,
-      fakeCensus2021.edu,
-      fakeCensus2021.eilr,
-      fakeCensus2021.hou,
-      fakeCensus2021.huc,
-      fakeCensus2021.lab,
-      fakeCensus2021.mig,
-      fakeCensus2021.sogi,
-      fakeCensus2021.ttw,
+      fakeCensus2021Public.dem,
+      fakeCensus2021Public.edu,
+      fakeCensus2021Public.eilr,
+      fakeCensus2021Public.hou,
+      fakeCensus2021Public.huc,
+      fakeCensus2021Public.lab,
+      fakeCensus2021Public.mig,
+      fakeCensus2021Public.sogi,
+      fakeCensus2021Public.ttw,
     ],
     publishing: []
   },
   // ONS sandbox
   sandbox: {
     web: [
+      fakeCensus2021.zero,
       fakeCensus2021.dem,
-      fakeCensus2021.edu,
-      fakeCensus2021.eilr,
-      fakeCensus2021.hou,
-      fakeCensus2021.huc,
-      fakeCensus2021.lab,
       fakeCensus2021.mig,
-      fakeCensus2021.sogi,
-      fakeCensus2021.ttw,
     ],
     publishing:[
       fakeCensus2021preview.zero,
-      fakeCensus2021.dem,
-      fakeCensus2021.edu,
-      fakeCensus2021.eilr,
-      fakeCensus2021.hou,
-      fakeCensus2021.huc,
-      fakeCensus2021.lab,
-      fakeCensus2021.mig,
-      fakeCensus2021.sogi,
-      fakeCensus2021.ttw,
+      fakeCensus2021preview.dem,
+      fakeCensus2021preview.mig,
     ],
   },
   // ONS staging


### PR DESCRIPTION
commit fe68cf6c8f6e5b7d0e25e6924dbc68140615864d (HEAD -> feat/publishing-dry-run-in-sandbox, origin/feat/publishing-dry-run-in-sandbox)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Oct 26 14:58:30 2022 +0100

    add 2021 dry-run publishing content to sandbox in content.ts