### PR TITLE
respect available_geotypes of classifications

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type VizData = {
   params: {
     variableGroup: VariableGroup;
     variable: Variable;
+    classification: Classification;
     category: Category;
   };
 };


### PR DESCRIPTION
### What

The map now respects the available_geotypes param of the selected classification.

### How to review

Should be clear from diffs. Note that the VizData type did not include "classification" in "params", though it was already there in the "selection" store, so I added this to the type definition.