### PR TITLE
use plan-b public s3 urls for dem-mig release data

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -223,8 +223,16 @@ export default {
   prod: {
     web: [
       Census2021.zero,
-      Census2021.dem,
-      Census2021.mig
+      {
+        contentJsonUrl:
+          "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-DEM.json",
+        contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/2021-dem-mig",
+      },
+      {
+        contentJsonUrl:
+          "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-MIG.json",
+        contentBaseUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/2021-dem-mig",
+      },
     ],
     publishing: [
       Census2021preview.zero,


### PR DESCRIPTION
if things go wrong, we can merge this to use our plan b data + config locations after publication time has passed