### PR TITLE
refactor breaks -> [minVal, ...breaks] to fix legend bug

### DIFF
--- a/src/components/BreaksChart.svelte
+++ b/src/components/BreaksChart.svelte
@@ -10,6 +10,9 @@
   export let snapTicks = true;
   export let categoryCode = "";
 
+  // handle case of only one breaks value
+  $: ticks = breaks.length === 1 ? [breaks[0], breaks[0]] : breaks;
+
   const pos = (val, breaks) => {
     if (val < breaks[0]) {
       return 0;
@@ -27,32 +30,32 @@
 </script>
 
 <div class="mt-3 box-border relative w-full h-5 mb-8 text-xs sm:text-base">
-  {#each breaks.slice(1) as brk, i}
+  {#each ticks.slice(1) as brk, i}
     <div
       class="absolute top-0 h-full"
-      style="width: {100 / (breaks.length - 1)}%; left: {i * (100 / (breaks.length - 1))}%; background-color: {colors[
+      style="width: {100 / (ticks.length - 1)}%; left: {i * (100 / (ticks.length - 1))}%; background-color: {colors[
         i
       ]};"
     />
-    <div class="line" style="left: {i * (100 / (breaks.length - 1))}%;" />
+    <div class="line" style="left: {i * (100 / (ticks.length - 1))}%;" />
     <div
       class="tick"
-      style="left: {i * (100 / (breaks.length - 1))}%; transform: translateX({i == 0 && snapTicks ? '-2px' : '-50%'});"
+      style="left: {i * (100 / (ticks.length - 1))}%; transform: translateX({i == 0 && snapTicks ? '-2px' : '-50%'});"
     >
-      {roundCategoryDataToString(categoryCode, breaks[i])}<span class="tick-suffix">{suffix}</span>
+      {roundCategoryDataToString(categoryCode, ticks[i])}<span class="tick-suffix">{suffix}</span>
     </div>
   {/each}
   <div class="line" style="right: 0;" />
   <div class="tick" style="right: 0; transform: translateX({snapTicks ? '2px' : '50%'});">
-    {roundCategoryDataToString(categoryCode, breaks[breaks.length - 1])}<span class="tick-suffix">{suffix}</span>
+    {roundCategoryDataToString(categoryCode, ticks[ticks.length - 1])}<span class="tick-suffix">{suffix}</span>
   </div>
   {#if selected !== undefined}
-    <div class="absolute z-10 -top-2.5" style="left: calc({pos(selected, breaks)}% - {28 / 2}px);">
+    <div class="absolute z-10 -top-2.5" style="left: calc({pos(selected, ticks)}% - {28 / 2}px);">
       <BreaksMarker ghost={hovered} />
     </div>
   {/if}
   {#if hovered !== undefined}
-    <div class="absolute z-10 -top-2.5" style="left: calc({pos(hovered, breaks)}% - {28 / 2}px);">
+    <div class="absolute z-10 -top-2.5" style="left: calc({pos(hovered, ticks)}% - {28 / 2}px);">
       <BreaksMarker />
     </div>
   {/if}

--- a/src/components/MapLegend.svelte
+++ b/src/components/MapLegend.svelte
@@ -4,16 +4,12 @@
   import { selected } from "../stores/selected";
   import { formatTemplateString } from "../helpers/categoryHelpers";
   import { choroplethColours } from "../helpers/choroplethHelpers";
-  import {
-    getCategoryDataSuffix,
-    roundCategoryDataToString,
-    uniqueRoundedCategoryBreaks,
-  } from "../helpers/categoryHelpers";
+  import { getCategoryDataSuffix, roundCategoryDataToString } from "../helpers/categoryHelpers";
   import BreaksChart from "./BreaksChart.svelte";
   import GeoTypeBadge from "./GeoTypeBadge.svelte";
 
   $: valueForHoveredGeography = $viz?.places.find((p) => p.geoCode === $hovered?.geoCode)?.ratioToTotal;
-  $: breaks = $viz ? [$viz?.minMaxVals[0], ...$viz.breaks] : undefined;
+  $: breaks = $viz ? $viz.breaks : undefined;
 
   // the hovered, otherwise the selected, geography properties
   $: active = $hovered
@@ -113,7 +109,7 @@
           selected={$selected?.value}
           hovered={active.value}
           suffix={getCategoryDataSuffix($viz.params.category.code)}
-          breaks={uniqueRoundedCategoryBreaks($viz.params.category.code, breaks)}
+          breaks={breaks}
           colors={choroplethColours}
           categoryCode={$viz.params.category.code}
         />

--- a/src/components/MapLegend.svelte
+++ b/src/components/MapLegend.svelte
@@ -109,7 +109,7 @@
           selected={$selected?.value}
           hovered={active.value}
           suffix={getCategoryDataSuffix($viz.params.category.code)}
-          breaks={breaks}
+          {breaks}
           colors={choroplethColours}
           categoryCode={$viz.params.category.code}
         />

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -6,7 +6,7 @@ import { roundedCategoryData, uniqueRoundedCategoryBreaks } from "../helpers/cat
 const geoBaseUrl = "https://cdn.ons.gov.uk/maptiles/cm-geos/v2";
 
 /*
-  Fetch place data files for all data 'tiles' (predefined coordinate grid squares) that intersect with current viewport 
+  Fetch place data files for all data 'tiles' (predefined coordinate grid squares) that intersect with current viewport
   bounding box.
 */
 export const fetchDataForBbox = async (args: { category: Category; geoType: GeoType; bbox: Bbox }) => {
@@ -39,7 +39,7 @@ const parsePlaceData = (row: dsv.DSVRowString<string>, categoryCode: string) => 
 };
 
 /*
-  Fetch json with census data by for categories categoryCode and totalCode for all geographies of type 'geoType' that 
+  Fetch json with census data by for categories categoryCode and totalCode for all geographies of type 'geoType' that
   fall within geographic bounding box represented by 'tile'.
 */
 export const fetchTileData = async (args: { category: Category; geoType: GeoType; tile: DataTile }) => {
@@ -56,13 +56,13 @@ export const fetchTileData = async (args: { category: Category; geoType: GeoType
 export const fetchBreaks = async (args: {
   category: Category;
   geoType: GeoType;
-}): Promise<{ breaks: { [categoryCode: string]: number[] }; minMax: { [categoryCode: string]: number[] } }> => {
+}): Promise<{ breaks: number[]; }> => {
   const url = `${args.category.baseUrl}/breaks/${args.geoType}/${args.category.code}.json`;
   const response = await fetch(url);
   const breaksRaw = await response.json();
-  /* 
+  /*
     breaks json files have legacy format from when it was an API response:
-    e.g. 
+    e.g.
     {
       "KS103EW0002": {
         "LAD": [
@@ -79,19 +79,14 @@ export const fetchBreaks = async (args: {
       }
     }
   */
-  const breaks = Object.fromEntries(
-    Object.keys(breaksRaw).map((code) => [
-      code,
-      uniqueRoundedCategoryBreaks(args.category.code, breaksRaw[code][args.geoType.toUpperCase()]),
-    ]),
-  );
-  const minMax = Object.fromEntries(
-    Object.keys(breaksRaw).map((code) => [
-      code,
-      breaksRaw[code][`${args.geoType.toUpperCase()}_min_max`].map((n) => roundedCategoryData(args.category.code, n)),
-    ]),
-  );
-  return { breaks, minMax };
+  const breaks = uniqueRoundedCategoryBreaks(
+    args.category.code,
+    [
+      breaksRaw[args.category.code][`${args.geoType.toUpperCase()}_min_max`][0],
+      ...breaksRaw[args.category.code][args.geoType.toUpperCase()]
+    ],
+  )
+  return { breaks };
 };
 
 /*

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -169,6 +169,17 @@ const Census2021 = {
   },
 }
 
+const Census2021NoFlorence = {
+  dem:  {
+    contentJsonUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-DEM.json",
+    contentBaseUrl: "https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com",
+  },
+  mig:  {
+    contentJsonUrl: "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/content-json/2021/2021-MIG.json",
+    contentBaseUrl: "https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com",
+  },
+}
+
 
 const Census2021Local = {
   dem:  {
@@ -200,13 +211,13 @@ export default {
   // netlify
   netlify: {
     web: [
-      Census2021.dem,
+      Census2021NoFlorence.dem,
       fakeCensus2021Public.edu,
       fakeCensus2021Public.eilr,
       fakeCensus2021Public.hou,
       fakeCensus2021Public.huc,
       fakeCensus2021Public.lab,
-      Census2021.mig,
+      Census2021NoFlorence.mig,
       fakeCensus2021Public.sogi,
       fakeCensus2021Public.ttw,
     ],

--- a/src/map/renderMapViz.ts
+++ b/src/map/renderMapViz.ts
@@ -22,7 +22,8 @@ export const renderMapViz = (map: mapboxgl.Map, data: VizData | undefined) => {
 };
 
 const getChoroplethColour = (value: number, breaks: number[]) => {
-  for (const b of breaks.map((b, i) => ({ breakpoint: b, colour: choroplethColours[i] }))) {
+  const upperBreakBounds = breaks.slice(1);
+  for (const b of upperBreakBounds.map((b, i) => ({ breakpoint: b, colour: choroplethColours[i] }))) {
     if (value <= b.breakpoint) return b.colour;
   }
 };

--- a/src/map/renderMapViz.ts
+++ b/src/map/renderMapViz.ts
@@ -22,7 +22,12 @@ export const renderMapViz = (map: mapboxgl.Map, data: VizData | undefined) => {
 };
 
 const getChoroplethColour = (value: number, breaks: number[]) => {
-  const upperBreakBounds = breaks.slice(1);
+  let upperBreakBounds
+  if (breaks.length === 1) {
+    upperBreakBounds = breaks
+  } else {
+    upperBreakBounds = breaks.slice(1);
+  }
   for (const b of upperBreakBounds.map((b, i) => ({ breakpoint: b, colour: choroplethColours[i] }))) {
     if (value <= b.breakpoint) return b.colour;
   }

--- a/src/stores/viz.ts
+++ b/src/stores/viz.ts
@@ -27,8 +27,7 @@ export const viz = asyncDerived([params, viewport], async ([$params, $viewport])
 
   return {
     geoType: args.geoType,
-    breaks: breaks.breaks[args.category.code],
-    minMaxVals: breaks.minMax[args.category.code],
+    breaks: breaks.breaks,
     places: data,
     params: {
       ...$params,

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,6 @@ export type VariableData = { [catCode: string]: { count: number; total: number; 
 export type VizData = {
   geoType: GeoType;
   breaks: number[];
-  minMaxVals: number[];
   places: { geoCode: string; ratioToTotal: number }[];
   params: {
     variableGroup: VariableGroup;


### PR DESCRIPTION
### What

commit 760586e86ead9b19ea5c1e33eef3a50ab2720b10 (HEAD -> fix/scale-bar-wrong-colors-when-reduced-n-breaks, origin/fix/scale-bar-wrong-colors-when-reduced-n-breaks)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Nov 2 11:34:37 2022 +0000

    refactor breaks -> [minVal, ...breaks] to fix legend bug

    - refactor api.fetchBreaks to return a rounded, deduplicated array
    combining the breaks with the min value for the current category.
    - refactor renderMapViz.getChoropleth color to ignore first
    entry in breaks array
    - refactor map legend to remove redundant adding of min val to breaks
    and subsequen re-rounding / deduplication

    These changes needed to fix issue where the min val was only being
    removed from the breaks array the legend shows, but not from the
    choropleth shading routine, resulting in the legend being out-by-one
    relative to the map colorscheme

### How to review

see the original bug here - the map colors do not match the legend: https://www.ons.gov.uk/census/maps/choropleth/population/passports-held/passports-all-52a/middle-east-and-asia-south-east-asia-philippines?msoa=E02000459

should be fixed in the preview here: https://deploy-preview-264--dp-census-atlas.netlify.app/choropleth/population/passports-held/passports-all-52a/middle-east-and-asia-south-east-asia-philippines?msoa=E02000459

if you go to the same part of the deploy preview, its fixed: 

### Who can review

Anyone
