### PR TITLE
Hotfix/missing static files in build

### DIFF
--- a/workaround-sveltekit-3726.sh
+++ b/workaround-sveltekit-3726.sh
@@ -4,11 +4,22 @@
 APP_BASE_PATH=${VITE_APP_BASE_PATH:-"census-atlas"}
 APP_BASE_PATH_NO_LEADING_SLASH=${APP_BASE_PATH#/}
 
+# get top-level dir of APP_BASE_PATH by applying dirname until there's no slash in the result
+APP_BASE_PATH_TOP_LEVEL_DIR=$APP_BASE_PATH_NO_LEADING_SLASH
+while [[ $APP_BASE_PATH_TOP_LEVEL_DIR == *"/"* ]]
+do
+    APP_BASE_PATH_TOP_LEVEL_DIR=$(dirname $APP_BASE_PATH_TOP_LEVEL_DIR)
+done
+
 echo "Workaround Sveltekit issue 3726..."
 # https://github.com/sveltejs/kit/issues/3726
 echo "Re-rooting app to base path ${APP_BASE_PATH_NO_LEADING_SLASH}"
 
 pushd ./build/client
+    # make new app dir
     mkdir -p "$APP_BASE_PATH_NO_LEADING_SLASH"
-    mv _app "$APP_BASE_PATH_NO_LEADING_SLASH"/_app
+    # move everything except the new add dir itself into the new app dir
+    find . -maxdepth 1 -mindepth 1 -not -name "$APP_BASE_PATH_TOP_LEVEL_DIR" \
+        -exec mv '{}' "$APP_BASE_PATH_NO_LEADING_SLASH" \;
+   # mv _app "$APP_BASE_PATH_NO_LEADING_SLASH"/_app
 popd


### PR DESCRIPTION
### What

commit 1b0fca6d665736622ad672ffa1a2399a5788a727 (HEAD -> hotfix/missing-static-files-in-build, origin/hotfix/missing-static-files-in-build)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Nov 3 08:43:07 2022 +0000

    fix inclusion of static files in sveltekit >= 1.0 builds

    refactor the workaround-sveltekit-3726.sh script to include
    all files in build/client when re-rooting the app to a new
    base path.

    This change needed as static files are now placed
    here in sveltekit >= 1.0, rather than in a 'static' build
    directory, and so were not being included.

### How to review

- run local ons build with `npm run build:ons`
- run locally in netlify mode (other modes don't work locally with an ons build) with ` ENV_NAME=netlify PORT=28100 node build/index.js`
- `http://localhost:28100/census/maps/favicon.ico` should exist.
- 'http://localhost:28100/census/maps/img/og-image.png` should exist

### Who can review

Anyone