### PR TITLE
Fix URLs in Header

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -18,7 +18,7 @@
     </a>
   </div>
   <div class="fill-ons-census p-3">
-    <a href="https://census.gov.uk/" class="custom-ring">
+    <a href="/census" class="custom-ring">
       <Census2021 />
     </a>
   </div>

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -13,12 +13,14 @@
   class:bg-ons-ruby-red={$content.fakeDataLoaded}
 >
   <div class="">
-    <a href={buildHyperlink($page.url)} class="custom-ring">
+    <a href="/" class="custom-ring">
       <Logo />
     </a>
   </div>
   <div class="fill-ons-census p-3">
-    <Census2021 />
+    <a href="https://census.gov.uk/" class="custom-ring">
+      <Census2021 />
+    </a>
   </div>
   {#if $content.fakeDataLoaded}
     <div class="truncate">


### PR DESCRIPTION
ONS logo links to ONS homepage ("/") rather than Census Maps homepage.

New link added to ons.gov.uk/census from Census 2021 logo.

### What

The ONS logo link was pointing to Census Maps. It now points to "/"

The Census 2021 logo didn't have an `<a>` tag. It now points to ons.gov.uk/census

### How to review

Check that the links are correct and that I haven't changed the layout or accessibility.

### Who can review

Anyone.
