### PR TITLE
Feature/131 improve embed interface

### DIFF
--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -32,7 +32,7 @@
     embedAreaSearch,
     embedCategorySelection,
     embedView,
-    ...(embedView === "viewport" && {"embedBounds": embedBounds}), // don't include embed bounds unless we need to!
+    ...(embedView === "viewport" && { embedBounds: embedBounds }), // don't include embed bounds unless we need to!
   });
 
   onMount(() => {
@@ -123,7 +123,7 @@
     <div class="px-4 border-y-8 border-ons-grey-5 bg-ons-grey-5 text-sm font-mono break-all h-24 overflow-y-scroll">
       {embedCode.html}
     </div>
-    <div class="flex flex-col gap-3 pt-3">
+    <div class="flex flex-col gap-3 pt-1">
       <button
         class="flex items-center justify-center gap-2 custom-ring bg-ons-leaf-green hover:bg-[#0d753c] shadow shadow-[#073d20] text-onswhite font-semibold rounded py-3 px-4 whitespace-nowrap"
         style="text-rendering: optimizeLegibility"

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -116,7 +116,7 @@
       {/if}
     </div>
   </section>
-  <div class="p-5 mb-5 bg-ons-grey-5 text-sm font-mono break-all">
+  <div class="p-5 mb-5 bg-ons-grey-5 text-sm font-mono break-all h-28">
     {embedCode.html}
   </div>
   <div class="flex items-center justify-end gap-6">

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -82,17 +82,17 @@
     <div class="flex gap-4">
       <label class="hoverable">
         <input type="radio" bind:group={embedView} name="embedView" value={"geography"} />
-        Center on selected location ({$geography.displayName})
+        Centre on selected location ({$geography.displayName})
       </label>
       <label class="hoverable">
         <input type="radio" bind:group={embedView} name="embedView" value={"viewport"} />
-        Use exact area
+        Use current map viewport
       </label>
     </div>
     <div class="">
       <label class="hoverable">
         <input type="checkbox" bind:checked={embedInteractive} class="custom-ring mr-1" />
-        Interactive map
+        Allow map zoom and pan
       </label>
     </div>
     <div class="">

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -6,6 +6,7 @@
   import { fromEvent, Observable, of, concat } from "rxjs";
   import { delay, mergeMap, startWith, switchMap, tap, windowWhen } from "rxjs/operators";
   import { getEmbedCode } from "../helpers/embedHelper";
+  import { viewport } from "../stores/viewport";
   import Icon from "./MaterialIcon.svelte";
 
   let dialog: HTMLDialogElement;
@@ -16,11 +17,19 @@
   let embedAreaSearch = false;
   let embedView: "viewport" | "geography" = "geography";
 
+  $: embedEast = $viewport?.bbox.east;
+  $: embedNorth = $viewport?.bbox.north;
+  $: embedWest = $viewport?.bbox.west;
+  $: embedSouth = $viewport?.bbox.south;
   $: embedCode = getEmbedCode($page.url, {
     embed: true,
     embedInteractive,
     embedAreaSearch,
     embedView,
+    embedEast,
+    embedNorth,
+    embedWest,
+    embedSouth
   });
 
   onMount(() => {
@@ -73,11 +82,11 @@
     <!-- <h3 class="mb-4 text-lg font-semibold md:text-xl ">Options</h3> -->
     <div class="flex gap-4">
       <label class="hoverable">
-        <input disabled type="radio" bind:group={embedView} name="embedView" value={"geography"} />
+        <input type="radio" bind:group={embedView} name="embedView" value={"geography"} />
         Center on selected location ({$geography.displayName})
       </label>
       <label class="hoverable">
-        <input disabled type="radio" bind:group={embedView} name="embedView" value={"viewport"} />
+        <input type="radio" bind:group={embedView} name="embedView" value={"viewport"} />
         Use exact area
       </label>
     </div>

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -80,7 +80,7 @@
   <div class="mb-4">
     Select your preferred embed options and copy the HTML code. There is a preview of the embedded map below.
   </div>
-  <section class="flex gap-8 px-3 py-1">
+  <section class="flex gap-8 px-2 py-1">
     <div class="">
       <label class="hoverable">
         <input type="checkbox" bind:checked={embedInteractive} class="custom-ring mr-1" />
@@ -100,43 +100,45 @@
       </label>
     </div>
   </section>
-  <section class="flex gap-8 px-3 py-1 mb-5">
-    <!-- <h3 class="mb-4 text-lg font-semibold md:text-xl ">Options</h3> -->
+  <section class="flex gap-8 px-2 py-1 mb-5">
     <div class="flex gap-4">
       <label class="hoverable">
-        <input type="radio" bind:group={embedView} name="embedView" value={"geography"} />
+        <input type="radio" bind:group={embedView} name="embedView" value={"geography"} class="custom-ring" />
         Fit map to {$geography.displayName}
       </label>
       <label class="hoverable">
-        <input type="radio" bind:group={embedView} name="embedView" value={"viewport"} />
+        <input type="radio" bind:group={embedView} name="embedView" value={"viewport"} class="custom-ring" />
         Fit map to current view
       </label>
       {#if $geography.geoType !== "ew"}
         <label class="hoverable">
-          <input type="radio" bind:group={embedView} name="embedView" value={"ew"} />
+          <input type="radio" bind:group={embedView} name="embedView" value={"ew"} class="custom-ring" />
           Fit map to England and Wales
         </label>
       {/if}
     </div>
   </section>
-  <div class="p-5 mb-5 bg-ons-grey-5 text-sm font-mono break-all h-28">
-    {embedCode.html}
-  </div>
-  <div class="flex items-center justify-end gap-6">
-    <button
-      class="flex items-center justify-center gap-2 custom-ring bg-ons-leaf-green hover:bg-[#0d753c] shadow shadow-[#073d20] text-onswhite font-semibold rounded py-3 px-4"
-      style="text-rendering: optimizeLegibility"
-      bind:this={button}
-    >
-      <div>Copy to clipboard</div>
-      <div class="text-2xl">
-        <Icon kind="contentCopy" />
-      </div>
-    </button>
-    {#if $copied}
-      <div out:fade={{ duration: 1000 }}>Copied!</div>
-    {/if}
-  </div>
+  <section class="flex gap-6">
+    <div class="px-4 border-y-8 border-ons-grey-5 bg-ons-grey-5 text-sm font-mono break-all h-24 overflow-y-scroll">
+      {embedCode.html}
+    </div>
+    <div class="flex flex-col gap-3 pt-3">
+      <button
+        class="flex items-center justify-center gap-2 custom-ring bg-ons-leaf-green hover:bg-[#0d753c] shadow shadow-[#073d20] text-onswhite font-semibold rounded py-3 px-4 whitespace-nowrap"
+        style="text-rendering: optimizeLegibility"
+        bind:this={button}
+      >
+        <div>Copy to clipboard</div>
+        <div class="text-2xl">
+          <Icon kind="contentCopy" />
+        </div>
+      </button>
+      {#if $copied}
+        <div class="text-center" out:fade={{ duration: 1000 }}>Copied!</div>
+      {/if}
+    </div>
+  </section>
+
   <section class="mt-5">
     <iframe height="600px" width="100%" title="ONS Census Maps" frameborder="0" src={embedCode.url} />
   </section>

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -8,6 +8,7 @@
   import { getEmbedCode } from "../helpers/embedHelper";
   import { viewport } from "../stores/viewport";
   import Icon from "./MaterialIcon.svelte";
+  import type { FourNumberTuple } from "../types";
 
   let dialog: HTMLDialogElement;
   let button: HTMLButtonElement;
@@ -22,15 +23,15 @@
     $viewport?.bbox.west,
     $viewport?.bbox.south,
     $viewport?.bbox.east,
-    $viewport?.bbox.north
-  ]
+    $viewport?.bbox.north,
+  ] as FourNumberTuple;
   $: embedCode = getEmbedCode($page.url, {
     embed: true,
     embedInteractive,
     embedAreaSearch,
     embedCategorySelection,
     embedView,
-    embedBounds
+    embedBounds,
   });
 
   onMount(() => {
@@ -76,7 +77,9 @@
       </div>
     </div>
   </form>
-  <div class="mb-4">Select your preferred embed options and copy the HTML code. There is a preview of the embedded map below.</div>
+  <div class="mb-4">
+    Select your preferred embed options and copy the HTML code. There is a preview of the embedded map below.
+  </div>
   <section class="flex gap-8 px-3 py-1">
     <div class="">
       <label class="hoverable">
@@ -108,7 +111,7 @@
         <input type="radio" bind:group={embedView} name="embedView" value={"viewport"} />
         Fit map to current view
       </label>
-      {#if ($geography.geoType != "ew")}
+      {#if $geography.geoType !== "ew"}
         <label class="hoverable">
           <input type="radio" bind:group={embedView} name="embedView" value={"ew"} />
           Fit map to England and Wales

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -25,13 +25,14 @@
     $viewport?.bbox.east,
     $viewport?.bbox.north,
   ] as FourNumberTuple;
+
   $: embedCode = getEmbedCode($page.url, {
     embed: true,
     embedInteractive,
     embedAreaSearch,
     embedCategorySelection,
     embedView,
-    embedBounds,
+    ...(embedView === "viewport" && {"embedBounds": embedBounds}), // don't include embed bounds unless we need to!
   });
 
   onMount(() => {

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -17,19 +17,18 @@
   let embedAreaSearch = false;
   let embedView: "viewport" | "geography" = "geography";
 
-  $: embedEast = $viewport?.bbox.east;
-  $: embedNorth = $viewport?.bbox.north;
-  $: embedWest = $viewport?.bbox.west;
-  $: embedSouth = $viewport?.bbox.south;
+  $: embedBounds = [
+    $viewport?.bbox.west,
+    $viewport?.bbox.south,
+    $viewport?.bbox.east,
+    $viewport?.bbox.north
+  ]
   $: embedCode = getEmbedCode($page.url, {
     embed: true,
     embedInteractive,
     embedAreaSearch,
     embedView,
-    embedEast,
-    embedNorth,
-    embedWest,
-    embedSouth
+    embedBounds
   });
 
   onMount(() => {

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -15,7 +15,8 @@
 
   let embedInteractive = false;
   let embedAreaSearch = false;
-  let embedView: "viewport" | "geography" = "geography";
+  let embedCategorySelection = false;
+  let embedView: "viewport" | "geography" | "ew" = "geography";
 
   $: embedBounds = [
     $viewport?.bbox.west,
@@ -27,6 +28,7 @@
     embed: true,
     embedInteractive,
     embedAreaSearch,
+    embedCategorySelection,
     embedView,
     embedBounds
   });
@@ -74,31 +76,41 @@
       </div>
     </div>
   </form>
-  <section class="mb-3">
-    <iframe height="600px" width="100%" title="ONS Census Maps" frameborder="0" src={embedCode.url} />
-  </section>
-  <section class="flex gap-8 bg-ons-grey-5 px-6 py-3 border-t-ons-grey-15 border-t-[1px] mb-5">
-    <!-- <h3 class="mb-4 text-lg font-semibold md:text-xl ">Options</h3> -->
-    <div class="flex gap-4">
-      <label class="hoverable">
-        <input type="radio" bind:group={embedView} name="embedView" value={"geography"} />
-        Centre on selected location ({$geography.displayName})
-      </label>
-      <label class="hoverable">
-        <input type="radio" bind:group={embedView} name="embedView" value={"viewport"} />
-        Use current map viewport
-      </label>
-    </div>
+  <div class="mb-4">Select your preferred embed options and copy the HTML code. There is a preview of the embedded map below.</div>
+  <section class="flex gap-8 px-3 py-1">
     <div class="">
       <label class="hoverable">
         <input type="checkbox" bind:checked={embedInteractive} class="custom-ring mr-1" />
-        Allow map zoom and pan
+        Enable map zoom and pan
       </label>
     </div>
     <div class="">
       <label class="hoverable">
         <input disabled type="checkbox" bind:checked={embedAreaSearch} class="custom-ring mr-1" />
-        Include area search
+        Enable area search
+      </label>
+    </div>
+    <div class="">
+      <label class="hoverable">
+        <input disabled type="checkbox" bind:checked={embedCategorySelection} class="custom-ring mr-1" />
+        Enable category selection
+      </label>
+    </div>
+  </section>
+  <section class="flex gap-8 px-3 py-1 mb-5">
+    <!-- <h3 class="mb-4 text-lg font-semibold md:text-xl ">Options</h3> -->
+    <div class="flex gap-4">
+      <label class="hoverable">
+        <input type="radio" bind:group={embedView} name="embedView" value={"geography"} />
+        Centre map on {$geography.displayName}
+      </label>
+      <label class="hoverable">
+        <input type="radio" bind:group={embedView} name="embedView" value={"viewport"} />
+        Fit map to current view
+      </label>
+      <label class="hoverable">
+        <input type="radio" bind:group={embedView} name="embedView" value={"ew"} />
+        Fit map to England and Wales
       </label>
     </div>
   </section>
@@ -122,4 +134,7 @@
       <div out:fade={{ duration: 1000 }}>Copied!</div>
     {/if}
   </div>
+  <section class="mt-5">
+    <iframe height="600px" width="100%" title="ONS Census Maps" frameborder="0" src={embedCode.url} />
+  </section>
 </dialog>

--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -81,7 +81,7 @@
     <div class="">
       <label class="hoverable">
         <input type="checkbox" bind:checked={embedInteractive} class="custom-ring mr-1" />
-        Enable map zoom and pan
+        Enable zoom and pan
       </label>
     </div>
     <div class="">
@@ -102,24 +102,24 @@
     <div class="flex gap-4">
       <label class="hoverable">
         <input type="radio" bind:group={embedView} name="embedView" value={"geography"} />
-        Centre map on {$geography.displayName}
+        Fit map to {$geography.displayName}
       </label>
       <label class="hoverable">
         <input type="radio" bind:group={embedView} name="embedView" value={"viewport"} />
         Fit map to current view
       </label>
-      <label class="hoverable">
-        <input type="radio" bind:group={embedView} name="embedView" value={"ew"} />
-        Fit map to England and Wales
-      </label>
+      {#if ($geography.geoType != "ew")}
+        <label class="hoverable">
+          <input type="radio" bind:group={embedView} name="embedView" value={"ew"} />
+          Fit map to England and Wales
+        </label>
+      {/if}
     </div>
   </section>
-
-  <div class="mb-4">Use the following HTML code to add this map to your own website.</div>
   <div class="p-5 mb-5 bg-ons-grey-5 text-sm font-mono break-all">
     {embedCode.html}
   </div>
-  <div class="flex items-center gap-6">
+  <div class="flex items-center justify-end gap-6">
     <button
       class="flex items-center justify-center gap-2 custom-ring bg-ons-leaf-green hover:bg-[#0d753c] shadow shadow-[#073d20] text-onswhite font-semibold rounded py-3 px-4"
       style="text-rendering: optimizeLegibility"

--- a/src/helpers/embedHelper.ts
+++ b/src/helpers/embedHelper.ts
@@ -1,6 +1,11 @@
+import type { FourNumberTuple } from "../types";
+
 export const getEmbedCode = (url: URL, embedParams: EmbedParams) => {
+  //
+  // TODO: don't mutate a function parameter
+  //
   // delete bounds property if not embedding in viewport mode
-  if (embedParams.embedView != "viewport") {
+  if (embedParams.embedView !== "viewport") {
     delete embedParams.embedBounds;
   }
 
@@ -9,7 +14,6 @@ export const getEmbedCode = (url: URL, embedParams: EmbedParams) => {
     ...Object.fromEntries(Object.entries(embedParams)),
     embedView: embedParams.embedView, // avoid type error
   });
-
 
   const embedUrl = url.origin + url.pathname + "?" + params.toString();
 
@@ -23,11 +27,10 @@ export type EmbedParams = {
   embed: boolean;
   embedAreaSearch: boolean;
   embedInteractive: boolean;
-  embedCategorySelection: boolean,
+  embedCategorySelection: boolean;
   embedView: "viewport" | "geography" | "ew";
-  embedBounds?: [number, number, number, number];
+  embedBounds?: FourNumberTuple;
 };
-
 
 // type PickByType<T, Value> = {
 //   [P in keyof T as T[P] extends Value | undefined ? P : never]: T[P]

--- a/src/helpers/embedHelper.ts
+++ b/src/helpers/embedHelper.ts
@@ -23,8 +23,9 @@ export type EmbedParams = {
   embed: boolean;
   embedAreaSearch: boolean;
   embedInteractive: boolean;
-  embedView: "viewport" | "geography";
-  embedBounds?: number[];
+  embedCategorySelection: boolean,
+  embedView: "viewport" | "geography" | "ew";
+  embedBounds?: [number, number, number, number];
 };
 
 

--- a/src/helpers/embedHelper.ts
+++ b/src/helpers/embedHelper.ts
@@ -1,10 +1,7 @@
 export const getEmbedCode = (url: URL, embedParams: EmbedParams) => {
-  // delete bounding box properties to avoid long urls if not embedding in viewport mode
+  // delete bounds property if not embedding in viewport mode
   if (embedParams.embedView != "viewport") {
-    delete embedParams.embedEast;
-    delete embedParams.embedNorth;
-    delete embedParams.embedWest;
-    delete embedParams.embedSouth;
+    delete embedParams.embedBounds;
   }
 
   const params = new URLSearchParams({
@@ -27,10 +24,7 @@ export type EmbedParams = {
   embedAreaSearch: boolean;
   embedInteractive: boolean;
   embedView: "viewport" | "geography";
-  embedEast?: number;
-  embedNorth?: number;
-  embedWest?: number;
-  embedSouth?: number,
+  embedBounds?: number[];
 };
 
 

--- a/src/helpers/embedHelper.ts
+++ b/src/helpers/embedHelper.ts
@@ -1,14 +1,6 @@
 import type { FourNumberTuple } from "../types";
 
 export const getEmbedCode = (url: URL, embedParams: EmbedParams) => {
-  //
-  // TODO: don't mutate a function parameter
-  //
-  // delete bounds property if not embedding in viewport mode
-  if (embedParams.embedView !== "viewport") {
-    delete embedParams.embedBounds;
-  }
-
   const params = new URLSearchParams({
     ...Object.fromEntries(url.searchParams),
     ...Object.fromEntries(Object.entries(embedParams)),

--- a/src/helpers/embedHelper.ts
+++ b/src/helpers/embedHelper.ts
@@ -1,9 +1,18 @@
 export const getEmbedCode = (url: URL, embedParams: EmbedParams) => {
+  // delete bounding box properties to avoid long urls if not embedding in viewport mode
+  if (embedParams.embedView != "viewport") {
+    delete embedParams.embedEast;
+    delete embedParams.embedNorth;
+    delete embedParams.embedWest;
+    delete embedParams.embedSouth;
+  }
+
   const params = new URLSearchParams({
     ...Object.fromEntries(url.searchParams),
     ...Object.fromEntries(Object.entries(embedParams)),
     embedView: embedParams.embedView, // avoid type error
   });
+
 
   const embedUrl = url.origin + url.pathname + "?" + params.toString();
 
@@ -18,7 +27,12 @@ export type EmbedParams = {
   embedAreaSearch: boolean;
   embedInteractive: boolean;
   embedView: "viewport" | "geography";
+  embedEast?: number;
+  embedNorth?: number;
+  embedWest?: number;
+  embedSouth?: number,
 };
+
 
 // type PickByType<T, Value> = {
 //   [P in keyof T as T[P] extends Value | undefined ? P : never]: T[P]

--- a/src/helpers/embedHelper.ts
+++ b/src/helpers/embedHelper.ts
@@ -1,4 +1,4 @@
-import type { FourNumberTuple } from "../types";
+import { GeoTypes, type FourNumberTuple } from "../types";
 
 export const getEmbedCode = (url: URL, embedParams: EmbedParams) => {
   const params = new URLSearchParams({
@@ -20,10 +20,20 @@ export type EmbedParams = {
   embedAreaSearch: boolean;
   embedInteractive: boolean;
   embedCategorySelection: boolean;
-  embedView: "viewport" | "geography" | "ew";
+  embedView: "viewport" | "geography";
   embedBounds?: FourNumberTuple;
 };
 
 // type PickByType<T, Value> = {
 //   [P in keyof T as T[P] extends Value | undefined ? P : never]: T[P]
 // }
+
+export const getPageUrlNoGeoParam = (pageUrl) => {
+  const pageUrlNoGeoParam = new URL(pageUrl);
+  GeoTypes.forEach((geoParam) => {
+    if (pageUrlNoGeoParam.searchParams.has(geoParam)) {
+      pageUrlNoGeoParam.searchParams.delete(geoParam);
+    }
+  });
+  return pageUrlNoGeoParam;
+};

--- a/src/helpers/geographyHelper.ts
+++ b/src/helpers/geographyHelper.ts
@@ -1,4 +1,6 @@
-export const englandAndWalesBbox = [1, 55.8, -5, 49.7] as [number, number, number, number];
+import type { FourNumberTuple } from "../types";
+
+export const englandAndWalesBbox: FourNumberTuple = [1, 55.8, -5, 49.7];
 
 export const geoTypeDescriptions = {
   lad: "Local Authority Districts",

--- a/src/helpers/spatialHelper.ts
+++ b/src/helpers/spatialHelper.ts
@@ -1,4 +1,4 @@
-import type { Bbox, DataTileGrid, GeographyData, GeoType } from "../types";
+import type { Bbox, DataTileGrid, FourNumberTuple, GeographyData, GeoType } from "../types";
 import censusDataTileGrid from "../quadsDataTileGrid.json";
 import booleanIntersects from "@turf/boolean-intersects";
 import bboxPolygon from "@turf/bbox-polygon";
@@ -16,10 +16,7 @@ export const doBboxesIntersect = (args: { bbox1: Bbox; bbox2: Bbox }) => {
   return booleanIntersects(bbox1Feature, bbox2Feature);
 };
 
-export const doBboxArraysIntersect = (
-  bbox1: [number, number, number, number],
-  bbox2: [number, number, number, number],
-) => {
+export const doBboxArraysIntersect = (bbox1: FourNumberTuple, bbox2: FourNumberTuple) => {
   const bbox1Feature = bboxPolygon(bbox1);
   const bbox2Feature = bboxPolygon(bbox2);
   return booleanIntersects(bbox1Feature, bbox2Feature);

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -23,7 +23,6 @@ const maxAllowedZoom = 15;
 export const initMap = (container: HTMLElement) => {
   const embed = get(params).embed;
   const interactive = !embed || embed.interactive;
-  const embedViewport = embed && embed.view === "viewport";
 
   const map = new Map({
     container,
@@ -41,12 +40,7 @@ export const initMap = (container: HTMLElement) => {
   // disable touchscreen rotate while allowing pinch-to-zoom
   map.touchZoomRotate.disableRotation();
 
-  if (embedViewport) {
-    const bounds = new mapboxgl.LngLatBounds(embed.embedBounds);
-    map.fitBounds(bounds, { padding: 0, animate: false });
-  } else {
-    setPosition(map, get(geography));
-  }
+  setInitialMapView(map, embed);
 
   if (interactive) {
     map.addControl(new mapboxgl.NavigationControl({ showCompass: false }));
@@ -171,3 +165,18 @@ const emptyFeatureCollection = {
   type: "FeatureCollection",
   features: [],
 };
+
+const setInitialMapView = (map, embed) => {
+  const embedViewport = embed && embed.view === "viewport";
+  const embedEW = embed && embed.view === "ew";
+
+  if (embedViewport) {
+    const bounds = new mapboxgl.LngLatBounds(embed.bounds);
+    map.fitBounds(bounds, { padding: 0, animate: false });
+  } else if (embedEW) {
+    const bounds = new mapboxgl.LngLatBounds(englandAndWalesBbox);
+    map.fitBounds(bounds, { padding: 0, animate: false });
+  } else {
+    setPosition(map, get(geography));
+  }
+}

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -168,15 +168,10 @@ const emptyFeatureCollection = {
 
 const setInitialMapView = (map, embed) => {
   const embedViewport = embed && embed.view === "viewport";
-  const embedEW = embed && embed.view === "ew";
-
   if (embedViewport) {
     const bounds = new mapboxgl.LngLatBounds(embed.bounds);
-    map.fitBounds(bounds, { padding: 0, animate: false });
-  } else if (embedEW) {
-    const bounds = new mapboxgl.LngLatBounds(englandAndWalesBbox);
     map.fitBounds(bounds, { padding: 0, animate: false });
   } else {
     setPosition(map, get(geography));
   }
-}
+};

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -42,7 +42,7 @@ export const initMap = (container: HTMLElement) => {
   map.touchZoomRotate.disableRotation();
 
   if (embedViewport) {
-    const bounds = new mapboxgl.LngLatBounds([embed.embedWest, embed.embedSouth], [embed.embedEast, embed.embedNorth]);
+    const bounds = new mapboxgl.LngLatBounds(embed.embedBounds);
     map.fitBounds(bounds, { padding: 0, animate: false });
   } else {
     setPosition(map, get(geography));

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -23,6 +23,7 @@ const maxAllowedZoom = 15;
 export const initMap = (container: HTMLElement) => {
   const embed = get(params).embed;
   const interactive = !embed || embed.interactive;
+  const embedViewport = embed && embed.view === "viewport";
 
   const map = new Map({
     container,
@@ -40,7 +41,13 @@ export const initMap = (container: HTMLElement) => {
   // disable touchscreen rotate while allowing pinch-to-zoom
   map.touchZoomRotate.disableRotation();
 
-  setPosition(map, get(geography));
+  if (embedViewport) {
+    const bounds = new mapboxgl.LngLatBounds([embed.embedWest, embed.embedSouth], [embed.embedEast, embed.embedNorth]);
+    map.fitBounds(bounds, { padding: 0, animate: false });
+  } else {
+    setPosition(map, get(geography));
+  }
+
   if (interactive) {
     map.addControl(new mapboxgl.NavigationControl({ showCompass: false }));
   }

--- a/src/map/initMapLayers.ts
+++ b/src/map/initMapLayers.ts
@@ -7,7 +7,7 @@ import type { FourNumberTuple } from "../types";
 
 const layerBounds: FourNumberTuple = [-6.418, 49.864, 1.764, 55.812];
 
-export const initMapLayers = (map, geo) => {
+export const initMapLayers = (map, geo, interactive: boolean) => {
   layersWithSiblings().forEach((l) => {
     map.addSource(l.layer.name, {
       type: "vector",
@@ -93,13 +93,15 @@ export const initMapLayers = (map, geo) => {
       hovered.set(undefined);
     });
 
-    // cursor to pointer when hovered
-    map.on("mouseenter", `${l.layer.name}-features`, () => {
-      map.getCanvas().style.cursor = "pointer";
-    });
-    map.on("mouseleave", `${l.layer.name}-features`, () => {
-      map.getCanvas().style.cursor = "";
-    });
+    if (interactive) {
+      // cursor to pointer when hovered
+      map.on("mouseenter", `${l.layer.name}-features`, () => {
+        map.getCanvas().style.cursor = "pointer";
+      });
+      map.on("mouseleave", `${l.layer.name}-features`, () => {
+        map.getCanvas().style.cursor = "";
+      });
+    }
 
     // when the user moves their mouse over the state-fill layer, we'll update the
     // feature state for the feature under the mouse.

--- a/src/map/initMapLayers.ts
+++ b/src/map/initMapLayers.ts
@@ -3,7 +3,9 @@ import { layersWithSiblings } from "./layers";
 import { centroidsGeojson } from "../helpers/quadsHelper";
 import { distinctUntilChanged, fromEventPattern } from "rxjs";
 import { map as project } from "rxjs/operators";
-const layerBounds: [number, number, number, number] = [-6.418, 49.864, 1.764, 55.812];
+import type { FourNumberTuple } from "../types";
+
+const layerBounds: FourNumberTuple = [-6.418, 49.864, 1.764, 55.812];
 
 export const initMapLayers = (map, geo) => {
   layersWithSiblings().forEach((l) => {
@@ -46,7 +48,7 @@ export const initMapLayers = (map, geo) => {
         // maxzoom: l.next ? l.next.minZoom : maxAllowedZoom,
         layout: {
           "line-join": "round",
-          visibility: l.layer.name == "lad" ? "visible" : "none"
+          visibility: l.layer.name == "lad" ? "visible" : "none",
         },
         paint: {
           "line-color": [
@@ -143,7 +145,7 @@ export const initMapLayers = (map, geo) => {
     id: "selected-geography-highlight",
     type: "line",
     source: "selected-geography",
-    layout: {"line-join": "round"},
+    layout: { "line-join": "round" },
     paint: {
       "line-color": "#fff",
       "line-width": 4.5,
@@ -153,7 +155,7 @@ export const initMapLayers = (map, geo) => {
     id: "selected-geography-outline",
     type: "line",
     source: "selected-geography",
-    layout: {"line-join": "round"},
+    layout: { "line-join": "round" },
     paint: {
       "line-color": "#000",
       "line-width": 3,

--- a/src/map/style.ts
+++ b/src/map/style.ts
@@ -1,5 +1,7 @@
 import type mapboxgl from "mapbox-gl";
-export const maxBounds: [number, number, number, number] = [-9, 47, 4, 61];
+import type { FourNumberTuple } from "../types";
+
+export const maxBounds: FourNumberTuple = [-9, 47, 4, 61];
 
 export const style: mapboxgl.Style = {
   "version": 8,

--- a/src/stores/params.ts
+++ b/src/stores/params.ts
@@ -21,15 +21,22 @@ export const params = derived([page, content], ([$page, $content]) => {
 });
 
 const parseSearchParams = (params: URLSearchParams) => {
+  let embedParams = undefined;
+  if (params.get("embed") === "true") {
+    embedParams = {
+      interactive: params.get("embedInteractive") === "true",
+      areaSearch: params.get("embedAreaSearch") === "true",
+      view: params.get("embedView"),
+    }
+    if  (params.get("embedView") === "viewport") {
+      embedParams.embedEast = params.get("embedEast");
+      embedParams.embedNorth = params.get("embedNorth");
+      embedParams.embedWest = params.get("embedWest");
+      embedParams.embedSouth = params.get("embedSouth");
+    }
+  }
   return {
     ...getSelectedGeography(params),
-    embed:
-      params.get("embed") === "true"
-        ? {
-            interactive: params.get("embedInteractive") === "true",
-            areaSearch: params.get("embedAreaSearch") === "true",
-            view: params.get("embedView"),
-          }
-        : undefined,
+    embed: embedParams
   };
 };

--- a/src/stores/params.ts
+++ b/src/stores/params.ts
@@ -29,7 +29,7 @@ const parseSearchParams = (params: URLSearchParams) => {
       view: params.get("embedView"),
     }
     if  (params.get("embedView") === "viewport") {
-      embedParams.embedBounds = params.get("embedBounds").split(",").map((b) => parseFloat(b));
+      embedParams.bounds = params.get("embedBounds").split(",").map((b) => parseFloat(b));
     }
   }
   return {

--- a/src/stores/params.ts
+++ b/src/stores/params.ts
@@ -29,10 +29,7 @@ const parseSearchParams = (params: URLSearchParams) => {
       view: params.get("embedView"),
     }
     if  (params.get("embedView") === "viewport") {
-      embedParams.embedEast = params.get("embedEast");
-      embedParams.embedNorth = params.get("embedNorth");
-      embedParams.embedWest = params.get("embedWest");
-      embedParams.embedSouth = params.get("embedSouth");
+      embedParams.embedBounds = params.get("embedBounds").split(",").map((b) => parseFloat(b));
     }
   }
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,8 @@ export type Category = {
 };
 export type VariableData = { [catCode: string]: { count: number; total: number; percentage: number } };
 
+export type FourNumberTuple = [number, number, number, number];
+
 export type VizData = {
   geoType: GeoType;
   breaks: number[];


### PR DESCRIPTION
Update embedding options and dialog with @bothness latest design: [trello](https://trello.com/c/EN4dpgfN)

commit b214849029f7d0c61a9cc397d3b679fa67856d20 (HEAD -> feature/131-improve-embed-interface, origin/feature/131-improve-embed-interface)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Thu Nov 3 15:10:18 2022 +0000

    embedding modal redesign, add england and wales view option

    - refactor embedding modal so that map is at bottom
    - add option to set embedded map view to all of england and wales
    - reword option labels
    - add (disabled) placeholder option for enabling category search

commit aaecc3c16e4adcee201a9edd30852c41cc428fbe (feature/embed-with-current-viewport)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Nov 2 08:21:52 2022 +0000

    update embed this modal option labels

commit 3d90ff4c688d4637128561b7ac9eb1d4cec8ead8
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Oct 31 20:28:04 2022 +0000

    array for embeddable viewport bounds URL parameter

    - use single array for embeddable viewport bounds URL
    parameter (embedBounds). Optional, will only be part of
    embeddable URL if embedView === 'viewport'.

commit 92e44fb153e562c7b0b4dbf9abc2be97d18d8ffb
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Oct 31 16:53:42 2022 +0000

    allow embedding with current viewport OR zoom to selected geography

    - enable radio buttons for embedView value selection in embedding
    modal
    - add optional embeddding url params for map bounding box
    - if embedding, initMap will either zoom to selected geography
    OR set map bounds to embedding bbox, depending on embedView value.
