### PR TITLE
ONS logo links to ons.gov.uk rather than Census Maps homepage.

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -13,12 +13,14 @@
   class:bg-ons-ruby-red={$content.fakeDataLoaded}
 >
   <div class="">
-    <a href={buildHyperlink($page.url)} class="custom-ring">
+    <a href="https://www.ons.gov.uk" class="custom-ring">
       <Logo />
     </a>
   </div>
   <div class="fill-ons-census p-3">
-    <Census2021 />
+    <a href="https://www.ons.gov.uk/census" class="custom-ring">
+      <Census2021 />
+    </a>
   </div>
   {#if $content.fakeDataLoaded}
     <div class="truncate">


### PR DESCRIPTION
### What

New link added to ons.gov.uk/census from Census 2021 logo.

Co-authored-by: James Trimble <James.Trimble@ons.gov.uk>


Describe what you have changed and why.

### How to review

read the code, click the links in the preview header and they should take you to the ONS homepage (ons logo) and ONS census page (census logo). 

### Who can review

Anyone