### PR TITLE
fix gitignore to ignore binaries

### DIFF
--- a/scripts/mktiles/.gitignore
+++ b/scripts/mktiles/.gitignore
@@ -1,2 +1,4 @@
-in
-out
+/in
+/out
+/mktiles
+/mktiles2


### PR DESCRIPTION
### What

Added mktiles binaries to .gitignore, narrowed scope of other .gitignore entries.

### How to review

eyeballs