### PR TITLE
use local logging for our atlas containers

### DIFF
--- a/scripts/atlas-host/docker-compose.yml
+++ b/scripts/atlas-host/docker-compose.yml
@@ -13,6 +13,10 @@ services:
       - type: bind
         source: /data
         target: /data
+    logging:
+      driver: local
+      options:
+        mode: non-blocking
     command: [ "sh", "-c", "/bin/chown ${ATLAS_USER}:${ATLAS_USER} /local; /usr/local/etc/sshd.sh" ]
     init: true
 


### PR DESCRIPTION
### What

The default container logging on the Atlas host is 'syslog'. This changes our containers to 'local' logging.