### PR TITLE
fix typos in MSOA names in geolookup.json

### DIFF
--- a/src/data/geoLookup2021.json
+++ b/src/data/geoLookup2021.json
@@ -14075,7 +14075,7 @@
     "geoCode": "E02005686"
   },
   {
-    "en": "Silverstone \u0026 Syresham \u0026 Helmdon",
+    "en": "Silverstone, \u0026 Syresham \u0026 Helmdon",
     "geoType": "MSOA",
     "geoCode": "E02005687"
   },
@@ -14453,7 +14453,7 @@
     "geoCode": "E02005806"
   },
   { "en": "Ayton \u0026 Snainton", "geoType": "MSOA", "geoCode": "E02005807" },
-  { "en": "Filey \u0026 Hummanby", "geoType": "MSOA", "geoCode": "E02005808" },
+  { "en": "Filey \u0026 Hunmanby", "geoType": "MSOA", "geoCode": "E02005808" },
   { "en": "Tadcaster", "geoType": "MSOA", "geoCode": "E02005809" },
   {
     "en": "Church Fenton, Appleton \u0026 Wistow",
@@ -17769,7 +17769,7 @@
     "geoCode": "E02006959"
   },
   {
-    "en": "University. Crescent \u0026 Adelphi Street",
+    "en": "University, Crescent \u0026 Adelphi Street",
     "geoType": "MSOA",
     "geoCode": "E02006960"
   },


### PR DESCRIPTION
### What

fix typos in MSOA names in geolookup.json:

E02005808: Filey & Hunmanby
E02006960: University, Crescent & Adelphi Street
E02005687: Silverstone, Syresham & Helmdon

### How to review

Check the values in geolookup.json are corrected as above

### Who can review

Anyone