### PR TITLE
match .CSV case-insensitive, fuzzy match "GeographyCode"

### DIFF
--- a/scripts/mktiles/cmd/mktiles2/main.go
+++ b/scripts/mktiles/cmd/mktiles2/main.go
@@ -217,7 +217,7 @@ func loadMetrics(dir string, atlas *geo.Atlas, m *metric2.M, doFake, doRatios bo
 	//	}
 	//}
 	log.Printf("loading metrics files")
-	if err := m.LoadAll(dir); err != nil {
+	if err := m.LoadAll(dir, MSOA_NAMES_CSV); err != nil {
 		return err
 	}
 	if doRatios {

--- a/scripts/mktiles/metric2/metric_test.go
+++ b/scripts/mktiles/metric2/metric_test.go
@@ -241,7 +241,7 @@ func Test_ImportCSV(t *testing.T) {
 
 		Convey("When a single-column CSV is imported", func() {
 			records := [][]string{
-				{"GeographyCode"},
+				{"Geography Code"}, // also tests fuzzy (0,0) comparison
 				{"geoA"},
 			}
 			err := m.ImportCSV(records)


### PR DESCRIPTION
### What

Match "GeographyCode" in metrics files with any spaces and case-insensitively. So, eg, " geography code " will be accepted.

Match the .CSV extension in metrics files case-insensitively. Know to skip msoa-names.csv because it isn't a metrics file.