### PR TITLE
display all SOGI classifications with 2dp precision

### DIFF
--- a/e2e/releases.spec.ts
+++ b/e2e/releases.spec.ts
@@ -59,7 +59,7 @@ const testCases = [
     name: "SOGI",
     url: "/choropleth/identity/gender-identity/gender-identity-4a/gender-identity-different-from-sex-registered-at-birth?msoa=E02003604",
     legendText:
-      "22.8% of families in Biggleswade East MSOA have a gender identity different from their sex registered at birth",
+      "22.84% of families in Biggleswade East MSOA have a gender identity different from their sex registered at birth",
     categoryCount: 3,
     nextClassificationCategoryCount: 7,
   },

--- a/src/helpers/classificationHelpers.ts
+++ b/src/helpers/classificationHelpers.ts
@@ -14,7 +14,15 @@ const classificationDataDisplayConfig = (classificationCode: string) => {
       roundBreaks: (breaks: number[]) => uniqueRoundedNumbers({ numbers: breaks, decimalPlaces: 0 }),
     };
   }
-  const twoDecimalPlaceClassifications = ["main_language_detailed", "main_language_detailed_23a"];
+  const twoDecimalPlaceClassifications = [
+    "main_language_detailed",
+    "main_language_detailed_23a",
+    "gender_identity_4a",
+    "gender_identity_8a",
+    "sexual_orientation_4a",
+    "sexual_orientation_6a",
+    "sexual_orientation_9a",
+  ];
   if (twoDecimalPlaceClassifications.includes(classificationCode)) {
     return {
       suffix: "%",


### PR DESCRIPTION
### What

All SOGI variables should be displayed to 2 decimal places

### How to review

👀  the code
Check the netlify preview to see if all sogi clasifications (all under identity/gender-identity, identity/sexual-orientation) have two decimal places

### Who can review

Anyone