### PR TITLE
ignore NaNs in metrics file inputs for mktiles (skip row if found)

### DIFF
--- a/scripts/mktiles/metric2/metric.go
+++ b/scripts/mktiles/metric2/metric.go
@@ -167,6 +167,10 @@ func (m *M) ImportCSV(records [][]string) error {
 			if !math.IsNaN(float64(cur)) {
 				return fmt.Errorf("row %d: col %d: duplicate", csvrow, csvcol)
 			}
+			if record[csvcol] == "NA" {
+				log.Printf("NA in row %d: col %d: skipping", csvrow, csvcol)
+				continue // skip NA rows
+			}
 			v, err := strconv.ParseFloat(record[csvcol], 64)
 			if err != nil {
 				return fmt.Errorf("row %d: col %d: %w", csvrow, csvcol, err)


### PR DESCRIPTION
some metrics file inputs for the HOU topic have NaNs in them (seems to be in there as 'NA', which might be an excel thing). The correct action for these should be to skip this row but carry on processing the file (it means that the geo for that row will have no data, but thats ok in this case!). Code added here as a quick and dirty patch just to get the data processed - @wavemechanics feel free to polish!
