### PR TITLE
add package-lock.json to docker concourse build to fix npm install

### DIFF
--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -4,6 +4,7 @@ WORKDIR /app/
 
 COPY build build
 COPY package.json .
+COPY package-lock.json .
 
 RUN npm install --silent
 

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -8,5 +8,5 @@ pushd dp-census-atlas
   make build-ons
   
   # copy build to the location expected by the CI
-  cp -r build package.json Dockerfile.concourse ../build
+  cp -r build package.json package-lock.json Dockerfile.concourse ../build
 popd


### PR DESCRIPTION
### What

docker image builds weren't working. Following the internets advice added the package-lock.json as well as package.json to the dockerfile. This fixed the builds locally.

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
