### PR TITLE
update content for metadata v38

### DIFF
--- a/scripts/content/2021-content-spec.json
+++ b/scripts/content/2021-content-spec.json
@@ -1,5 +1,5 @@
 {
-  "cantabular_metadata_dir": "ar2776-c21ew_metadata-v1-3_cantab_20221216-37",
+  "cantabular_metadata_dir": "ar2776-c21ew_metadata-v1-3_cantab_20230104-38",
   "variable_groups": [
     {
       "name": "Population",

--- a/scripts/content/output_content_jsons/2021-ALL.json
+++ b/scripts/content/output_content_jsons/2021-ALL.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-ALL-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-ALL-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {
@@ -4850,7 +4850,7 @@
           "code": "main_language_detailed",
           "slug": "main-language-detailed",
           "desc": "People's first or preferred language.",
-          "long_desc": "A person's first or preferred language.\n\nThis shows a detailed breakdown of the responses given in the write-in option \"Other, write in\".",
+          "long_desc": "A person's first or preferred language. \n\nThis breaks down the responses given in the write-in option \"Other, write in (including British Sign Language)\".",
           "units": "Person",
           "topic_code": "EILR",
           "classifications": [

--- a/scripts/content/output_content_jsons/2021-ARM.json
+++ b/scripts/content/output_content_jsons/2021-ARM.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-ARM-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-ARM-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-DEM.json
+++ b/scripts/content/output_content_jsons/2021-DEM.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-DEM-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-DEM-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-EDU.json
+++ b/scripts/content/output_content_jsons/2021-EDU.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-EDU-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-EDU-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-EILR.json
+++ b/scripts/content/output_content_jsons/2021-EILR.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-EILR-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-EILR-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {
@@ -649,7 +649,7 @@
           "code": "main_language_detailed",
           "slug": "main-language-detailed",
           "desc": "People's first or preferred language.",
-          "long_desc": "A person's first or preferred language.\n\nThis shows a detailed breakdown of the responses given in the write-in option \"Other, write in\".",
+          "long_desc": "A person's first or preferred language. \n\nThis breaks down the responses given in the write-in option \"Other, write in (including British Sign Language)\".",
           "units": "Person",
           "topic_code": "EILR",
           "classifications": [

--- a/scripts/content/output_content_jsons/2021-HOU.json
+++ b/scripts/content/output_content_jsons/2021-HOU.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-HOU-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-HOU-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-HUC.json
+++ b/scripts/content/output_content_jsons/2021-HUC.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-HUC-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-HUC-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-LAB.json
+++ b/scripts/content/output_content_jsons/2021-LAB.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-LAB-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-LAB-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-MIG.json
+++ b/scripts/content/output_content_jsons/2021-MIG.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-MIG-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-MIG-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-SOGI.json
+++ b/scripts/content/output_content_jsons/2021-SOGI.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-SOGI-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-SOGI-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-TTW.json
+++ b/scripts/content/output_content_jsons/2021-TTW.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-TTW-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-TTW-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {

--- a/scripts/content/output_content_jsons/2021-WELSH-SKILLS.json
+++ b/scripts/content/output_content_jsons/2021-WELSH-SKILLS.json
@@ -1,7 +1,7 @@
 {
   "meta": {
-    "created_at": "2022-12-21-12-15-43",
-    "release": "2021-WELSH-SKILLS-ar2776-c21ew_metadata-v1-3_cantab_20221216-37"
+    "created_at": "2023-01-04-13-14-36",
+    "release": "2021-WELSH-SKILLS-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
     {


### PR DESCRIPTION
### What

update content for metadata v38

### How to review
- 👀 
- go to the preview and check it all looks good - only difference is that the long description for main language detailed has been updated:
  - old version: [https://www.ons.gov.uk/census/maps/choropleth/identity/main-language-detailed/main-language-detailed-23a/english-english-or-welsh-if-in-wales](https://www.ons.gov.uk/census/maps/choropleth/identity/main-language-detailed/main-language-detailed-23a/english-english-or-welsh-if-in-wales)
  - new version [https://deploy-preview-384--dp-census-atlas.netlify.app/choropleth/identity/main-language-detailed/main-language-detailed-23a/english-english-or-welsh-if-in-wales](https://deploy-preview-384--dp-census-atlas.netlify.app/choropleth/identity/main-language-detailed/main-language-detailed-23a/english-english-or-welsh-if-in-wales)
 

### Who can review

Anyone