### PR TITLE
fix logging messages in content/make-florence-zips.sh

### DIFF
--- a/scripts/content/make-florence-zips.sh
+++ b/scripts/content/make-florence-zips.sh
@@ -16,7 +16,7 @@ pushd output_content_jsons
 popd
 
 # LAB, TTW and WELSH-SKILLS go in the censusmapsconfiglab visualisation
-echo "Zipping HOU for censusmapsconfighou visualisation"
+echo "Zipping LAB, TTW, and WELSH-SKILLS for censusmapsconfiglab visualisation"
 pushd output_content_jsons
     zipname="censusmapsconfiglab-${created_at}.zip"
     zip "$zipname" \


### PR DESCRIPTION
tiny fix - the helper script for making florence zips said it was putting the wrong stuff into the wrong zip (behaviour was correct, logging was wrong)
