### PR TITLE
Feature/mktiles2 processes raw metrics files

### DIFF
--- a/scripts/mktiles/README.md
+++ b/scripts/mktiles/README.md
@@ -202,6 +202,18 @@ This is being used for development before real-looking 2021 data is available.
 This directory must be empty or must not exist at all.
 If you stop a run midway, you will have to remove the output directory yourself before re-running the program.
 
+`-c` (optional) sets the path to the input content json, if it is not `in/content.json`
+
+`-C` (optional) sets the name of the classification code to process, if you want to do only one classification. _All_
+from the content json will be processed if this option is not used.
+
+`-M` (optional) means "match on category names" - use this option to match the wanted categories based on their names,
+rather than their codes. This is useful as often the raw metrics files only have the category names as headers.
+
+`-P` (optional) means "category name prefix". When `-M` is set, the value of this arg will be used as a prefix when
+matching category names (does nothing if `-M` is not set). This is useful as often the raw files will prefix the
+category name in the wanted columns, e.g. `Percentage point change: <name of category>`.
+
 So, assuming default input and output directories, you could do this for 2011:
 
 	./mktiles -R

--- a/scripts/mktiles/cmd/mktiles2/main.go
+++ b/scripts/mktiles/cmd/mktiles2/main.go
@@ -38,7 +38,7 @@ func main() {
 	contentName := flag.String("c", "", "path to content.json (default content.json within input dir)")
 	classCode := flag.String("C", "", "classification code to match in content.json (blank means all)")
 	doCatNameMatching := flag.Bool("M", false, "match categories from input files based on name rather than code")
-	catNamePrefix := flag.String("N", "", "when doCatNameMatching=true, optional prefix for cat names as they are found in input files")
+	catNamePrefix := flag.String("P", "", "when doCatNameMatching=true, optional prefix for cat names as they are found in input files")
 	ignoreMissingCats := flag.Bool("i", false, "ignore missing categories (useful is processing only part of a content json)")
 	flag.Parse()
 

--- a/scripts/mktiles/cmd/mktiles2/main.go
+++ b/scripts/mktiles/cmd/mktiles2/main.go
@@ -39,6 +39,7 @@ func main() {
 	classCode := flag.String("C", "", "classification code to match in content.json (blank means all)")
 	doCatNameMatching := flag.Bool("M", false, "match categories from input files based on name rather than code")
 	catNamePrefix := flag.String("N", "", "when doCatNameMatching=true, optional prefix for cat names as they are found in input files")
+	ignoreMissingCats := flag.Bool("i", false, "ignore missing categories (useful is processing only part of a content json)")
 	flag.Parse()
 
 	if *contentName == "" {
@@ -114,7 +115,9 @@ func main() {
 			for _, cat := range missingCats {
 				log.Printf("\t%s", cat)
 			}
-			log.Fatal("missing categories in metrics files")
+			if !*ignoreMissingCats {
+				log.Fatal("missing categories in metrics files")
+			}
 		}
 	}
 

--- a/scripts/mktiles/cmd/mktiles2/main.go
+++ b/scripts/mktiles/cmd/mktiles2/main.go
@@ -37,6 +37,8 @@ func main() {
 	force := flag.Bool("f", false, "force using an existing out directory")
 	contentName := flag.String("c", "", "path to content.json (default content.json within input dir)")
 	classCode := flag.String("C", "", "classification code to match in content.json (blank means all)")
+	doCatNameMatching := flag.Bool("M", false, "match categories from input files based on name rather than code")
+	catNamePrefix := flag.String("N", "", "when doCatNameMatching=true, optional prefix for cat names as they are found in input files")
 	flag.Parse()
 
 	if *contentName == "" {
@@ -49,6 +51,8 @@ func main() {
 	log.Printf("          calc ratios: %t", *doRatios)
 	log.Printf("generate fake metrics: %t", *doFake)
 	log.Printf("                force: %t", *force)
+	log.Printf("matching cats by name: %t", *doCatNameMatching)
+	log.Printf("using cat name prefix: %s", *catNamePrefix)
 
 	if err := setupOutDir(*outdir, *force); err != nil {
 		log.Fatal(err)
@@ -67,6 +71,14 @@ func main() {
 		log.Fatal(err)
 	}
 	log.Printf("found %d categories", len(wantcats))
+
+	//
+	// make cat name to cat code map
+	//
+	namesToCats, err := cont.NamesToCats(*classCode, *catNamePrefix)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	//
 	// load grid file
@@ -93,7 +105,7 @@ func main() {
 	//
 	if !*doFake {
 		log.Printf("loading metrics files")
-		if err := m.LoadAll(*indir, MSOA_NAMES_CSV); err != nil {
+		if err := m.LoadAll(*indir, MSOA_NAMES_CSV, *doCatNameMatching, namesToCats); err != nil {
 			log.Fatal(err)
 		}
 		missingCats := m.MissingCats()

--- a/scripts/mktiles/content/content.go
+++ b/scripts/mktiles/content/content.go
@@ -2,5 +2,5 @@ package content
 
 type Content interface {
 	Categories(classcode string) ([]string, error)
-	NamesToCats(classcode string) (map[string]string, error)
+	NamesToCats(classcode string, prefix string) (map[string]string, error)
 }

--- a/scripts/mktiles/content/contentv1/content.go
+++ b/scripts/mktiles/content/contentv1/content.go
@@ -86,7 +86,7 @@ func (v1 *V1) Categories(classcode string) ([]string, error) {
 // NamesToCats creates a map to lookup a category code given a category name.
 // This is used when converting plain text headings in spreadsheets to specific
 // category codes.
-func (v1 *V1) NamesToCats(classcode string) (map[string]string, error) {
+func (v1 *V1) NamesToCats(classcode string, prefix string) (map[string]string, error) {
 	catmap := map[string]string{}
 
 	for _, content := range v1.Content {
@@ -101,7 +101,7 @@ func (v1 *V1) NamesToCats(classcode string) (map[string]string, error) {
 						if ok {
 							return nil, fmt.Errorf("duplicate: %q", cat.Name)
 						}
-						catmap[cat.Name] = cat.Code
+						catmap[prefix+cat.Name] = cat.Code
 					}
 				}
 			}

--- a/scripts/mktiles/content/contentv1/content_test.go
+++ b/scripts/mktiles/content/contentv1/content_test.go
@@ -68,7 +68,7 @@ func Test_Load(t *testing.T) {
 
 		Convey("Name to Category map should be built", func() {
 			want := map[string]string{}
-			got, err := v1.NamesToCats("wrong classification code")
+			got, err := v1.NamesToCats("wrong classification code", "")
 			So(err, ShouldBeNil)
 			So(got, ShouldResemble, want)
 
@@ -79,7 +79,7 @@ func Test_Load(t *testing.T) {
 				"Highest level of qualification: Level 4 qualifications and above": "highest_qualification_6a-003",
 				"Highest level of qualification: Other qualifications":             "highest_qualification_6a-004",
 			}
-			got, err = v1.NamesToCats("highest_qualification_6a")
+			got, err = v1.NamesToCats("highest_qualification_6a", "")
 			So(err, ShouldBeNil)
 			So(got, ShouldResemble, want)
 
@@ -92,11 +92,11 @@ func Test_Load(t *testing.T) {
 				"Level 4 qualifications and above: degree (BA, BSc), higher degree (MA, PhD, PGCE), NVQ level 4 to 5, HNC, HND, RSA Higher Diploma, BTEC Higher level, professional qualifications (for example, teaching, nursing, accountancy)":                                                     "highest_qualification-005",
 				"Other: vocational or work-related qualifications, other qualifications achieved in England or Wales, qualifications achieved outside England or Wales (equivalent not stated or unknown)":                                                                                            "highest_qualification-006",
 			}
-			got, err = v1.NamesToCats("highest_qualification")
+			got, err = v1.NamesToCats("highest_qualification", "")
 			So(err, ShouldBeNil)
 			So(got, ShouldResemble, want)
 
-			got, err = v1.NamesToCats("")
+			got, err = v1.NamesToCats("", "")
 			So(err, ShouldNotBeNil)
 			So(got, ShouldBeNil)
 		})

--- a/scripts/mktiles/content/contentv2/content.go
+++ b/scripts/mktiles/content/contentv2/content.go
@@ -79,7 +79,7 @@ func (v2 *V2) Categories(classcode string) ([]string, error) {
 // NamesToCats creates a map to lookup a category code given a category name.
 // This is used when converting plain text headings in spreadsheets to specific
 // category codes.
-func (v2 *V2) NamesToCats(classcode string) (map[string]string, error) {
+func (v2 *V2) NamesToCats(classcode string, prefix string,) (map[string]string, error) {
 	catmap := map[string]string{}
 
 	for _, content := range v2.Content {
@@ -93,7 +93,7 @@ func (v2 *V2) NamesToCats(classcode string) (map[string]string, error) {
 					if ok {
 						return nil, fmt.Errorf("duplicate: %q", cat.Name)
 					}
-					catmap[cat.Name] = cat.Code
+					catmap[prefix+cat.Name] = cat.Code
 				}
 			}
 		}

--- a/scripts/mktiles/content/contentv3/content.go
+++ b/scripts/mktiles/content/contentv3/content.go
@@ -72,7 +72,7 @@ func (v3 *V3) Categories(classcode string) ([]string, error) {
 // NamesToCats creates a map to lookup a category code given a category name.
 // This is used when converting plain text headings in spreadsheets to specific
 // category codes.
-func (v3 *V3) NamesToCats(classcode string) (map[string]string, error) {
+func (v3 *V3) NamesToCats(classcode string, prefix string) (map[string]string, error) {
 	catmap := map[string]string{}
 
 	for _, content := range v3.Content {
@@ -85,7 +85,7 @@ func (v3 *V3) NamesToCats(classcode string) (map[string]string, error) {
 				if ok {
 					return nil, fmt.Errorf("duplicate: %q", cat.Name)
 				}
-				catmap[cat.Name] = cat.Code
+				catmap[prefix+cat.Name] = cat.Code
 			}
 		}
 	}

--- a/scripts/mktiles/content/contentv3/content_test.go
+++ b/scripts/mktiles/content/contentv3/content_test.go
@@ -40,22 +40,23 @@ func Test_Load(t *testing.T) {
 
 		Convey("Name to Category map should be built", func() {
 			want := map[string]string{}
-			got, err := v3.NamesToCats("wrong classification code")
+			got, err := v3.NamesToCats("wrong classification code", "")
 			So(err, ShouldBeNil)
 			So(got, ShouldResemble, want)
 
 			want = map[string]string{
-				"Household is not deprived in any dimension": "hh_deprivation-001",
-				"Household is deprived in one dimension":     "hh_deprivation-002",
-				"Household is deprived in two dimensions":    "hh_deprivation-003",
-				"Household is deprived in three dimensions":  "hh_deprivation-004",
-				"Household is deprived in four dimensions":   "hh_deprivation-005",
+				"2021 Value change: Household is not deprived in any dimension": "hh_deprivation-001",
+				"2021 Value change: Household is deprived in one dimension":     "hh_deprivation-002",
+				"2021 Value change: Household is deprived in two dimensions":    "hh_deprivation-003",
+				"2021 Value change: Household is deprived in three dimensions":  "hh_deprivation-004",
+				"2021 Value change: Household is deprived in four dimensions":   "hh_deprivation-005",
 			}
-			got, err = v3.NamesToCats("")
+			catNamePrefix := "2021 Value change: "
+			got, err = v3.NamesToCats("", catNamePrefix)
 			So(err, ShouldBeNil)
 			So(got, ShouldResemble, want)
 
-			got, err = v3.NamesToCats("hh_deprivation")
+			got, err = v3.NamesToCats("hh_deprivation", catNamePrefix)
 			So(err, ShouldBeNil)
 			So(got, ShouldResemble, want)
 		})

--- a/scripts/mktiles/metric2/cat_test.go
+++ b/scripts/mktiles/metric2/cat_test.go
@@ -89,7 +89,7 @@ func Test_CalcRatios(t *testing.T) {
 				{"geoB", "16", "2", "4"},
 				{"geoC", "20", "5", "4"},
 			}
-			err := m.ImportCSV("test", records)
+			err := m.ImportCSV("test", records, false, map[string]string{})
 			So(err, ShouldBeNil)
 
 			Convey("ratios should be calculated", func() {


### PR DESCRIPTION
### What

commit d68bef95b89d1ab4277abe4dabcf0ccf474e21f7 (HEAD -> feature/mktiles2-processes-raw-metrics-files, origin/feature/mktiles2-processes-raw-metrics-files)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Fri Jan 6 09:26:41 2023 +0000

    option to warn not fail mktiles2 if missing categories

commit b913e483e817f1e24415bb91e8f6e0ea8115143e
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Wed Jan 4 11:25:25 2023 +0000

    mktiles2 can match metrics to content json based on category name

    - finish implementing namesToCats in mktiles2. Now has additional
    CLI args to register wanted categories on metrics files using
    category name (with optional prefix, e.g. 'Percentage change: ')
    rather than category code. This change needed to ingest raw files
    without needing to manually add the category codes.

### How to review

- 👀 
- run the tests from `scripts/mktiles/metric2` with `go test`
- if you can find suitable input, try it out!

### Who can review

@wavemechanics 