### PR TITLE
implement simple geolock for embeds

### DIFF
--- a/src/components/EmbedThis.svelte
+++ b/src/components/EmbedThis.svelte
@@ -20,6 +20,8 @@
   let embedCategorySelection = false;
   let embedView: "viewport" | "geography" = "geography";
   let embedSelectGeo = true;
+  let doGeoLock = false;
+  $: geoLock = $viewport?.geoType || "ew";
 
   $: embedBounds = [
     $viewport?.bbox.west,
@@ -37,6 +39,7 @@
     embedCategorySelection,
     embedView,
     ...(embedView === "viewport" && { embedBounds: embedBounds }), // don't include embed bounds unless we need to!
+    ...(doGeoLock && { geoLock: geoLock }), // don't include geoLock unless we need to!
   });
 
   onMount(() => {
@@ -103,6 +106,12 @@
       <label class="hoverable">
         <input type="checkbox" bind:checked={embedCategorySelection} class="custom-ring mr-1" />
         Category selection
+      </label>
+    </div>
+    <div class="">
+      <label class="hoverable">
+        <input type="checkbox" bind:checked={doGeoLock} class="custom-ring mr-1" />
+        Lock geotype to {geoLock.toUpperCase()}
       </label>
     </div>
   </section>

--- a/src/helpers/embedHelper.ts
+++ b/src/helpers/embedHelper.ts
@@ -1,5 +1,5 @@
 import { isNumeric } from "../util/numberUtil";
-import { GeoTypes, type NumberQuadruple } from "../types";
+import { GeoTypes, type GeoType, type NumberQuadruple } from "../types";
 
 export const getEmbedCode = (url: URL, embedParams: EmbedUrlParams) => {
   const params = new URLSearchParams({

--- a/src/helpers/paramsHelper.ts
+++ b/src/helpers/paramsHelper.ts
@@ -12,3 +12,10 @@ export const getSelectedGeography = (params: URLSearchParams) => {
   }
   return { geoType: englandAndWales.meta.geotype as GeoType, geoCode: englandAndWales.meta.code };
 };
+
+export const getGeoLock = (params: URLSearchParams) => {
+  if (params.has("geoLock")) {
+    return { geoLock: params.get("geoLock") as GeoType };
+  }
+  return {};
+};

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -3,7 +3,7 @@ import { page } from "$app/stores";
 import mapboxgl, { GeoJSONSource, Map } from "mapbox-gl";
 import { combineLatest, fromEvent, merge } from "rxjs";
 import { throttleTime } from "rxjs/operators";
-import type { GeoType, GeographyInfo, Classification } from "../types";
+import { type GeoType, type GeographyInfo, type Classification, GeoTypes } from "../types";
 import { params } from "../stores/params";
 import { geography } from "../stores/geography";
 import { englandAndWalesBbox } from "../helpers/geographyHelper";
@@ -60,7 +60,7 @@ export const initMap = (container: HTMLElement) => {
       throttleTime(1000, undefined, { leading: false, trailing: true }), // don't discard the final movement
     )
     .subscribe(([_, $params]) => {
-      setViewportStoreAndLayerVisibility(map, $params.classification);
+      setViewportStoreAndLayerVisibility(map, $params.classification, $params?.geoLock);
     });
 
   if (interactive) {
@@ -75,10 +75,19 @@ export const initMap = (container: HTMLElement) => {
   return map;
 };
 
-const setViewportStoreAndLayerVisibility = (map: mapboxgl.Map, classification: Classification) => {
+const setViewportStoreAndLayerVisibility = (
+  map: mapboxgl.Map,
+  classification: Classification,
+  geoLock: GeoType | undefined,
+) => {
   const b = map.getBounds();
   const bbox = { east: b.getEast(), north: b.getNorth(), west: b.getWest(), south: b.getSouth() };
-  const geoType = getGeoType(map, classification);
+  let geoType;
+  if (geoLock) {
+    geoType = { actual: geoLock, ideal: geoLock };
+  } else {
+    geoType = getGeoType(map, classification);
+  }
 
   setMapLayerVisibility(map, geoType.actual);
 

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -43,6 +43,11 @@ export const initMap = (container: HTMLElement) => {
 
   map.touchZoomRotate.disableRotation();
 
+  if (get(params)?.geoLock) {
+    const minZoomForGeoLock = layers.find((l) => l.name === get(params).geoLock).minZoom;
+    map.setMinZoom(minZoomForGeoLock);
+  }
+
   if (interactive) {
     map.addControl(new mapboxgl.NavigationControl({ showCompass: false }));
   }

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -3,7 +3,7 @@ import { page } from "$app/stores";
 import mapboxgl, { GeoJSONSource, Map } from "mapbox-gl";
 import { combineLatest, fromEvent, merge } from "rxjs";
 import { throttleTime } from "rxjs/operators";
-import { type GeoType, type GeographyInfo, type Classification, GeoTypes } from "../types";
+import type { GeoType, GeographyInfo, Classification } from "../types";
 import { params } from "../stores/params";
 import { geography } from "../stores/geography";
 import { englandAndWalesBbox } from "../helpers/geographyHelper";

--- a/src/map/initMap.ts
+++ b/src/map/initMap.ts
@@ -44,8 +44,13 @@ export const initMap = (container: HTMLElement) => {
   map.touchZoomRotate.disableRotation();
 
   if (get(params)?.geoLock) {
-    const minZoomForGeoLock = layers.find((l) => l.name === get(params).geoLock).minZoom;
-    map.setMinZoom(minZoomForGeoLock);
+    if (get(params).geoLock === "oa") {
+      // 9 seems a sensible compromise min zoom for urban and rural areas when OA is geolocked
+      map.setMinZoom(9);
+    } else {
+      const minZoomForGeoLock = layers.find((l) => l.name === get(params).geoLock).minZoom;
+      map.setMinZoom(minZoomForGeoLock);
+    }
   }
 
   if (interactive) {

--- a/src/map/layers.ts
+++ b/src/map/layers.ts
@@ -15,7 +15,7 @@ export const layers = [
   {
     name: "msoa" as GeoType,
     urlTemplate: "https://cdn.ons.gov.uk/maptiles/administrative/2021/msoa/v2/boundaries/{z}/{x}/{y}.pbf",
-    minZoom: 8,
+    minZoom: 6,
     defaultZoom: 9.5,
     sourceMaxZoom: 12,
     geoPadFactor: 5,
@@ -26,8 +26,8 @@ export const layers = [
   {
     name: "oa" as GeoType,
     urlTemplate: "https://cdn.ons.gov.uk/maptiles/administrative/2021/oa/v2/boundaries/{z}/{x}/{y}.pbf",
-    minZoom: 10,
-    defaultZoom: 11,
+    minZoom: 8,
+    defaultZoom: 10,
     sourceMaxZoom: 12,
     geoPadFactor: 3,
     idProperty: "areacd",

--- a/src/map/layers.ts
+++ b/src/map/layers.ts
@@ -15,7 +15,7 @@ export const layers = [
   {
     name: "msoa" as GeoType,
     urlTemplate: "https://cdn.ons.gov.uk/maptiles/administrative/2021/msoa/v2/boundaries/{z}/{x}/{y}.pbf",
-    minZoom: 6,
+    minZoom: 8,
     defaultZoom: 9.5,
     sourceMaxZoom: 12,
     geoPadFactor: 5,
@@ -26,8 +26,8 @@ export const layers = [
   {
     name: "oa" as GeoType,
     urlTemplate: "https://cdn.ons.gov.uk/maptiles/administrative/2021/oa/v2/boundaries/{z}/{x}/{y}.pbf",
-    minZoom: 8,
-    defaultZoom: 10,
+    minZoom: 10,
+    defaultZoom: 11,
     sourceMaxZoom: 12,
     geoPadFactor: 3,
     idProperty: "areacd",

--- a/src/stores/params.ts
+++ b/src/stores/params.ts
@@ -1,7 +1,7 @@
 import { derived } from "svelte/store";
 import { page } from "$app/stores";
 import { content } from "./content";
-import { getSelectedGeography } from "../helpers/paramsHelper";
+import { getSelectedGeography, getGeoLock } from "../helpers/paramsHelper";
 import { parseEmbedParams } from "../helpers/embedHelper";
 
 /**
@@ -19,6 +19,7 @@ export const params = derived([page, content], ([$page, $content]) => {
     classification,
     category,
     ...getSelectedGeography($page.url.searchParams),
+    ...getGeoLock($page.url.searchParams),
     ...parseEmbedParams($page.url.searchParams),
   };
 });


### PR DESCRIPTION
### What

commit 9961d0a7f4431a0e793cc43d26556835b3ef9823 (HEAD -> feature/lockable-geotypes-for-embed, origin/feature/lockable-geotypes-for-embed)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Jan 10 12:38:44 2023 +0000

    restrict min zoom to 9 for geoLocked OA only

    - When query param geoLock=oa, restrict map min zoom level to 9.
    This seems a reasonable compromise between rural and urban areas
    when geolocked to OA (when not geolocked the min zoom can be as low
    as 8 for OA, but this will only be actually available to the user
    in areas with very few OA's on screen at any one time)

commit 22e56c6080bed19c9dc07d362b5a8419b07820be
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Jan 10 10:37:47 2023 +0000

    Revert "adjust min zoom for geolevels"

    This reverts commit 959ff7e1199b8e4c0e536723e55569743a458d5a.

commit 959ff7e1199b8e4c0e536723e55569743a458d5a
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Jan 9 15:22:52 2023 +0000

    adjust min zoom for geolevels

commit 6aa65eb5d4d89fa35de0eb1dce439cd624d07b22
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Jan 9 14:51:10 2023 +0000

    restrict min zoom when locking geotype in embeds

commit eb7c44c5aa697aa21dfc909ce36cc6161f674a7e
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Jan 9 12:41:18 2023 +0000

    fix type import in initMap.ts

commit 543d23abf5febb1b74105be51636263ad2bb6eac
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Jan 9 11:33:47 2023 +0000

    embeds can lock geotype to that currently shown on map

    - add 'Lock geotype to X' option for embeds. This uses URL
    query param 'lockGeo' to lock embedded map to only display the
    geotype currently selected on the main map regardless of zoom. This
    change needed to avoid issues where embedded map was not
    showing expected geotype due to geotype being autoselected based

### How To Review

- 👀 
- go to [https://deploy-preview-396--dp-census-atlas.netlify.app/](https://deploy-preview-396--dp-census-atlas.netlify.app/) and try the 'Lock geotype to XXX' option in the embed preview - should lock the geotype to that currently displayed on the main map

