### PR TITLE
add age-standardised variants of HUC variables + metadata v39

### DIFF
--- a/scripts/content/2021-content-spec.json
+++ b/scripts/content/2021-content-spec.json
@@ -296,12 +296,188 @@
             "classifications": ["disability_4a"]
           },
           {
+            "custom_variable": {
+              "name": "Disability (age-standardised)",
+              "code": "disability_age_standardised",
+              "slug": "disability-age-standardised",
+              "desc": "People with a long-term health problem or disability, including conditions relating to old-age.",
+              "long_desc": "People who assessed their day-to-day activities as limited by long-term physical or mental health conditions or illnesses are considered disabled. This definition of a disabled person meets the harmonised standard for measuring disability and is in line with the Equality Act (2010).",
+              "units": "Person",
+              "topic_code": "HUC",
+              "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+              "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+              "classifications": [
+                {
+                  "code": "disability_4a_age_standardised",
+                  "slug": "disability-4a",
+                  "desc": "Disability - Equality act disabled (4 categories)",
+                  "available_geotypes": ["lad"],
+                  "choropleth_default": true,
+                  "dot_density_default": true,
+                  "comparison_2011_data_available": true,
+                  "data_download": "https://www.ons.gov.uk/datasets/TS038/editions/2021",
+                  "categories": [
+                    {
+                      "name": "Disabled under the Equality Act: Day-to-day activities limited a lot",
+                      "slug": "disabled-under-the-equality-act-day-to-day-activities-limited-a-lot",
+                      "code": "disability_4a_age_standardised-001",
+                      "legend_str_1": "of people in {location}",
+                      "legend_str_2": "are",
+                      "legend_str_3": "disabled under the equality act: day-to-day activities limited a lot"
+                    },
+                    {
+                      "name": "Disabled under the Equality Act: Day-to-day activities limited a little",
+                      "slug": "disabled-under-the-equality-act-day-to-day-activities-limited-a-little",
+                      "code": "disability_4a_age_standardised-002",
+                      "legend_str_1": "of people in {location}",
+                      "legend_str_2": "are",
+                      "legend_str_3": "disabled under the equality act: day-to-day activities limited a little"
+                    },
+                    {
+                      "name": "Not disabled under the Equality Act",
+                      "slug": "not-disabled-under-the-equality-act",
+                      "code": "disability_4a_age_standardised-003",
+                      "legend_str_1": "of people in {location}",
+                      "legend_str_2": "are",
+                      "legend_str_3": "not disabled under the equality act"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "code": "health_in_general",
             "classifications": ["health_in_general"]
           },
           {
+            "custom_variable": {
+              "name": "General health (age-standardised)",
+              "code": "health_in_general_age_standardised",
+              "slug": "general-health-age-standardised",
+              "desc": "How people rate their general health.",
+              "long_desc": "A person's assessment of the general state of their health from very good to very bad. This assessment is not based on a person's health over any specified period of time.",
+              "units": "Household",
+              "topic_code": "HUC",
+              "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+              "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+              "classifications": [
+                {
+                  "code": "health_in_general",
+                  "slug": "health-in-general",
+                  "desc": "General health (6 categories)",
+                  "available_geotypes": ["lad"],
+                  "choropleth_default": true,
+                  "dot_density_default": true,
+                  "comparison_2011_data_available": true,
+                  "data_download": "https://www.ons.gov.uk/datasets/TS037/editions/2021",
+                  "categories": [
+                    {
+                      "name": "Very good health",
+                      "slug": "very-good-health",
+                      "code": "health_in_general_age_standardised-001",
+                      "legend_str_1": "of people in {location}",
+                      "legend_str_2": "have",
+                      "legend_str_3": "very good health"
+                    },
+                    {
+                      "name": "Good health",
+                      "slug": "good-health",
+                      "code": "health_in_general_age_standardised-002",
+                      "legend_str_1": "of people in {location}",
+                      "legend_str_2": "have",
+                      "legend_str_3": "good health"
+                    },
+                    {
+                      "name": "Fair health",
+                      "slug": "fair-health",
+                      "code": "health_in_general_age_standardised-003",
+                      "legend_str_1": "of people in {location}",
+                      "legend_str_2": "have",
+                      "legend_str_3": "fair health"
+                    },
+                    {
+                      "name": "Bad health",
+                      "slug": "bad-health",
+                      "code": "health_in_general_age_standardised-004",
+                      "legend_str_1": "of people in {location}",
+                      "legend_str_2": "have",
+                      "legend_str_3": "bad health"
+                    },
+                    {
+                      "name": "Very bad health",
+                      "slug": "very-bad-health",
+                      "code": "health_in_general_age_standardised-005",
+                      "legend_str_1": "of people in {location}",
+                      "legend_str_2": "have",
+                      "legend_str_3": "very bad health"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
             "code": "is_carer",
             "classifications": ["is_carer_5a"]
+          },
+          {
+            "custom_variable": {
+              "name": "Provision of unpaid care (age-standardised)",
+              "code": "is_carer_age_standardised",
+              "slug": "provision-of-unpaid-care-age-standardised",
+              "desc": "People who are unpaid carers.",
+              "long_desc": "An unpaid carer may look after, give help or support to anyone who has long-term physical or mental ill-health conditions, illness or problems related to old age.  \n\nThis does not include any activities as part of paid employment. \n\nThis help can be within or outside of the carer's household.",
+              "units": "Person",
+              "topic_code": "HUC",
+              "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+              "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+              "classifications": [
+                {
+                  "code": "is_carer_5a",
+                  "slug": "is-carer-5a",
+                  "desc": "Unpaid care (5 categories)",
+                  "available_geotypes": ["lad"],
+                  "choropleth_default": true,
+                  "dot_density_default": true,
+                  "comparison_2011_data_available": true,
+                  "categories": [
+                    {
+                      "name": "Provides no unpaid care",
+                      "slug": "provides-no-unpaid-care",
+                      "code": "is_carer_5a_age_standardised-001",
+                      "legend_str_1": "of people aged 5 years and over in {location}",
+                      "legend_str_2": "provide",
+                      "legend_str_3": "no unpaid care"
+                    },
+                    {
+                      "name": "Provides 19 or less hours unpaid care a week",
+                      "slug": "provides-19-or-less-hours-unpaid-care-a-week",
+                      "code": "is_carer_5a_age_standardised-002",
+                      "legend_str_1": "of people aged 5 years and over in {location}",
+                      "legend_str_2": "provide",
+                      "legend_str_3": "19 or less hours unpaid care a week"
+                    },
+                    {
+                      "name": "Provides 20 to 49 hours unpaid care a week",
+                      "slug": "provides-20-to-49-hours-unpaid-care-a-week",
+                      "code": "is_carer_5a_age_standardised-003",
+                      "legend_str_1": "of people aged 5 years and over in {location}",
+                      "legend_str_2": "provide",
+                      "legend_str_3": "20 to 49 hours unpaid care a week"
+                    },
+                    {
+                      "name": "Provides 50 or more hours unpaid care a week",
+                      "slug": "provides-50-or-more-hours-unpaid-care-a-week",
+                      "code": "is_carer_5a_age_standardised-004",
+                      "legend_str_1": "of people aged 5 years and over in {location}",
+                      "legend_str_2": "provide",
+                      "legend_str_3": "50 or more hours unpaid care a week"
+                    }
+                  ]
+                }
+              ]
+            }
           }
         ]
       }

--- a/scripts/content/input_metadata_files/classification_available_geotypes.csv
+++ b/scripts/content/input_metadata_files/classification_available_geotypes.csv
@@ -2,9 +2,9 @@ variable_group,content_json,variable,classification,available_geotypes
 Education,2021-EDU,highest_qualification,highest_qualification,"oa,msoa,lad"
 Education,2021-EDU,highest_qualification,highest_qualification_6a,"oa,msoa,lad"
 Education,2021-EDU,in_full_time_education,in_full_time_education,"oa,msoa,lad"
-Health,2021-HUC,disability,disability_4a,lad
-Health,2021-HUC,health_in_general,health_in_general,lad
-Health,2021-HUC,is_carer,is_carer_5a,lad
+Health,2021-HUC,disability,disability_4a,"oa,msoa,lad"
+Health,2021-HUC,health_in_general,health_in_general,"oa,msoa,lad"
+Health,2021-HUC,is_carer,is_carer_5a,"oa,msoa,lad"
 Housing,2021-HOU,accommodation_type,accommodation_type,"oa,msoa,lad"
 Housing,2021-HOU,accommodation_type,accommodation_type_3a,"oa,msoa,lad"
 Housing,2021-HOU,accommodation_type,accommodation_type_5a,"oa,msoa,lad"

--- a/scripts/content/input_metadata_files/variable_caveats.csv
+++ b/scripts/content/input_metadata_files/variable_caveats.csv
@@ -1,9 +1,9 @@
 variable_group,content_json,variable,caveat_text,caveat_link
 Education,2021-EDU,highest_qualification,,
 Education,2021-EDU,in_full_time_education,,
-Health,2021-HUC,disability,Figures for this variable are age standardised.,
-Health,2021-HUC,health_in_general,Figures for this variable are age standardised.,
-Health,2021-HUC,is_carer,Figures for this variable are age standardised.,
+Health,2021-HUC,disability,"Values are not age-standardised, so do not account for differences in population size and age structure.","http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021"
+Health,2021-HUC,health_in_general,"Values are not age-standardised, so do not account for differences in population size and age structure.","http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+Health,2021-HUC,is_carer,"Values are not age-standardised, so do not account for differences in population size and age structure.","http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
 Housing,2021-HOU,accommodation_type,,
 Housing,2021-HOU,alternative_address_indicator,,
 Housing,2021-HOU,heating_type,,

--- a/scripts/content/output_content_jsons/2021-ALL.json
+++ b/scripts/content/output_content_jsons/2021-ALL.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-ALL-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
@@ -8235,13 +8235,16 @@
           "long_desc": "People who assessed their day-to-day activities as limited by long-term physical or mental health conditions or illnesses are considered disabled. This definition of a disabled person meets the harmonised standard for measuring disability and is in line with the Equality Act (2010).",
           "units": "Person",
           "topic_code": "HUC",
-          "caveat_text": "Figures for this variable are age standardised.",
+          "caveat_text": "Values are not age-standardised, so do not account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
           "classifications": [
             {
               "code": "disability_4a",
               "slug": "disability-4a",
               "desc": "Disability - Equality act disabled (4 categories)",
               "available_geotypes": [
+                "oa",
+                "msoa",
                 "lad"
               ],
               "choropleth_default": true,
@@ -8278,6 +8281,57 @@
           ]
         },
         {
+          "name": "Disability (age-standardised)",
+          "code": "disability_age_standardised",
+          "slug": "disability-age-standardised",
+          "desc": "People with a long-term health problem or disability, including conditions relating to old-age.",
+          "long_desc": "People who assessed their day-to-day activities as limited by long-term physical or mental health conditions or illnesses are considered disabled. This definition of a disabled person meets the harmonised standard for measuring disability and is in line with the Equality Act (2010).",
+          "units": "Person",
+          "topic_code": "HUC",
+          "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+          "classifications": [
+            {
+              "code": "disability_4a_age_standardised",
+              "slug": "disability-4a",
+              "desc": "Disability - Equality act disabled (4 categories)",
+              "available_geotypes": [
+                "lad"
+              ],
+              "choropleth_default": true,
+              "dot_density_default": true,
+              "comparison_2011_data_available": true,
+              "data_download": "https://www.ons.gov.uk/datasets/TS038/editions/2021",
+              "categories": [
+                {
+                  "name": "Disabled under the Equality Act: Day-to-day activities limited a lot",
+                  "slug": "disabled-under-the-equality-act-day-to-day-activities-limited-a-lot",
+                  "code": "disability_4a_age_standardised-001",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "are",
+                  "legend_str_3": "disabled under the equality act: day-to-day activities limited a lot"
+                },
+                {
+                  "name": "Disabled under the Equality Act: Day-to-day activities limited a little",
+                  "slug": "disabled-under-the-equality-act-day-to-day-activities-limited-a-little",
+                  "code": "disability_4a_age_standardised-002",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "are",
+                  "legend_str_3": "disabled under the equality act: day-to-day activities limited a little"
+                },
+                {
+                  "name": "Not disabled under the Equality Act",
+                  "slug": "not-disabled-under-the-equality-act",
+                  "code": "disability_4a_age_standardised-003",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "are",
+                  "legend_str_3": "not disabled under the equality act"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "General health",
           "code": "health_in_general",
           "slug": "general-health",
@@ -8285,13 +8339,16 @@
           "long_desc": "A person's assessment of the general state of their health from very good to very bad. This assessment is not based on a person's health over any specified period of time.",
           "units": "Household",
           "topic_code": "HUC",
-          "caveat_text": "Figures for this variable are age standardised.",
+          "caveat_text": "Values are not age-standardised, so do not account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
           "classifications": [
             {
               "code": "health_in_general",
               "slug": "health-in-general",
               "desc": "General health (6 categories)",
               "available_geotypes": [
+                "oa",
+                "msoa",
                 "lad"
               ],
               "choropleth_default": true,
@@ -8344,6 +8401,73 @@
           ]
         },
         {
+          "name": "General health (age-standardised)",
+          "code": "health_in_general_age_standardised",
+          "slug": "general-health-age-standardised",
+          "desc": "How people rate their general health.",
+          "long_desc": "A person's assessment of the general state of their health from very good to very bad. This assessment is not based on a person's health over any specified period of time.",
+          "units": "Household",
+          "topic_code": "HUC",
+          "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+          "classifications": [
+            {
+              "code": "health_in_general",
+              "slug": "health-in-general",
+              "desc": "General health (6 categories)",
+              "available_geotypes": [
+                "lad"
+              ],
+              "choropleth_default": true,
+              "dot_density_default": true,
+              "comparison_2011_data_available": true,
+              "data_download": "https://www.ons.gov.uk/datasets/TS037/editions/2021",
+              "categories": [
+                {
+                  "name": "Very good health",
+                  "slug": "very-good-health",
+                  "code": "health_in_general_age_standardised-001",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "very good health"
+                },
+                {
+                  "name": "Good health",
+                  "slug": "good-health",
+                  "code": "health_in_general_age_standardised-002",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "good health"
+                },
+                {
+                  "name": "Fair health",
+                  "slug": "fair-health",
+                  "code": "health_in_general_age_standardised-003",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "fair health"
+                },
+                {
+                  "name": "Bad health",
+                  "slug": "bad-health",
+                  "code": "health_in_general_age_standardised-004",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "bad health"
+                },
+                {
+                  "name": "Very bad health",
+                  "slug": "very-bad-health",
+                  "code": "health_in_general_age_standardised-005",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "very bad health"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "Provision of unpaid care",
           "code": "is_carer",
           "slug": "provision-of-unpaid-care",
@@ -8351,13 +8475,16 @@
           "long_desc": "An unpaid carer may look after, give help or support to anyone who has long-term physical or mental ill-health conditions, illness or problems related to old age.  \n\nThis does not include any activities as part of paid employment. \n\nThis help can be within or outside of the carer's household.",
           "units": "Person",
           "topic_code": "HUC",
-          "caveat_text": "Figures for this variable are age standardised.",
+          "caveat_text": "Values are not age-standardised, so do not account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
           "classifications": [
             {
               "code": "is_carer_5a",
               "slug": "is-carer-5a",
               "desc": "Unpaid care (5 categories)",
               "available_geotypes": [
+                "oa",
+                "msoa",
                 "lad"
               ],
               "choropleth_default": true,
@@ -8392,6 +8519,64 @@
                   "name": "Provides 50 or more hours unpaid care a week",
                   "slug": "provides-50-or-more-hours-unpaid-care-a-week",
                   "code": "is_carer_5a-004",
+                  "legend_str_1": "of people aged 5 years and over in {location}",
+                  "legend_str_2": "provide",
+                  "legend_str_3": "50 or more hours unpaid care a week"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Provision of unpaid care (age-standardised)",
+          "code": "is_carer_age_standardised",
+          "slug": "provision-of-unpaid-care-age-standardised",
+          "desc": "People who are unpaid carers.",
+          "long_desc": "An unpaid carer may look after, give help or support to anyone who has long-term physical or mental ill-health conditions, illness or problems related to old age.  \n\nThis does not include any activities as part of paid employment. \n\nThis help can be within or outside of the carer's household.",
+          "units": "Person",
+          "topic_code": "HUC",
+          "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+          "classifications": [
+            {
+              "code": "is_carer_5a",
+              "slug": "is-carer-5a",
+              "desc": "Unpaid care (5 categories)",
+              "available_geotypes": [
+                "lad"
+              ],
+              "choropleth_default": true,
+              "dot_density_default": true,
+              "comparison_2011_data_available": true,
+              "categories": [
+                {
+                  "name": "Provides no unpaid care",
+                  "slug": "provides-no-unpaid-care",
+                  "code": "is_carer_5a_age_standardised-001",
+                  "legend_str_1": "of people aged 5 years and over in {location}",
+                  "legend_str_2": "provide",
+                  "legend_str_3": "no unpaid care"
+                },
+                {
+                  "name": "Provides 19 or less hours unpaid care a week",
+                  "slug": "provides-19-or-less-hours-unpaid-care-a-week",
+                  "code": "is_carer_5a_age_standardised-002",
+                  "legend_str_1": "of people aged 5 years and over in {location}",
+                  "legend_str_2": "provide",
+                  "legend_str_3": "19 or less hours unpaid care a week"
+                },
+                {
+                  "name": "Provides 20 to 49 hours unpaid care a week",
+                  "slug": "provides-20-to-49-hours-unpaid-care-a-week",
+                  "code": "is_carer_5a_age_standardised-003",
+                  "legend_str_1": "of people aged 5 years and over in {location}",
+                  "legend_str_2": "provide",
+                  "legend_str_3": "20 to 49 hours unpaid care a week"
+                },
+                {
+                  "name": "Provides 50 or more hours unpaid care a week",
+                  "slug": "provides-50-or-more-hours-unpaid-care-a-week",
+                  "code": "is_carer_5a_age_standardised-004",
                   "legend_str_1": "of people aged 5 years and over in {location}",
                   "legend_str_2": "provide",
                   "legend_str_3": "50 or more hours unpaid care a week"

--- a/scripts/content/output_content_jsons/2021-ARM.json
+++ b/scripts/content/output_content_jsons/2021-ARM.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-ARM-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-DEM.json
+++ b/scripts/content/output_content_jsons/2021-DEM.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-DEM-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-EDU.json
+++ b/scripts/content/output_content_jsons/2021-EDU.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-EDU-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-EILR.json
+++ b/scripts/content/output_content_jsons/2021-EILR.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-EILR-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-HOU.json
+++ b/scripts/content/output_content_jsons/2021-HOU.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-HOU-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-HUC.json
+++ b/scripts/content/output_content_jsons/2021-HUC.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-HUC-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [
@@ -17,13 +17,16 @@
           "long_desc": "People who assessed their day-to-day activities as limited by long-term physical or mental health conditions or illnesses are considered disabled. This definition of a disabled person meets the harmonised standard for measuring disability and is in line with the Equality Act (2010).",
           "units": "Person",
           "topic_code": "HUC",
-          "caveat_text": "Figures for this variable are age standardised.",
+          "caveat_text": "Values are not age-standardised, so do not account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
           "classifications": [
             {
               "code": "disability_4a",
               "slug": "disability-4a",
               "desc": "Disability - Equality act disabled (4 categories)",
               "available_geotypes": [
+                "oa",
+                "msoa",
                 "lad"
               ],
               "choropleth_default": true,
@@ -60,6 +63,57 @@
           ]
         },
         {
+          "name": "Disability (age-standardised)",
+          "code": "disability_age_standardised",
+          "slug": "disability-age-standardised",
+          "desc": "People with a long-term health problem or disability, including conditions relating to old-age.",
+          "long_desc": "People who assessed their day-to-day activities as limited by long-term physical or mental health conditions or illnesses are considered disabled. This definition of a disabled person meets the harmonised standard for measuring disability and is in line with the Equality Act (2010).",
+          "units": "Person",
+          "topic_code": "HUC",
+          "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+          "classifications": [
+            {
+              "code": "disability_4a_age_standardised",
+              "slug": "disability-4a",
+              "desc": "Disability - Equality act disabled (4 categories)",
+              "available_geotypes": [
+                "lad"
+              ],
+              "choropleth_default": true,
+              "dot_density_default": true,
+              "comparison_2011_data_available": true,
+              "data_download": "https://www.ons.gov.uk/datasets/TS038/editions/2021",
+              "categories": [
+                {
+                  "name": "Disabled under the Equality Act: Day-to-day activities limited a lot",
+                  "slug": "disabled-under-the-equality-act-day-to-day-activities-limited-a-lot",
+                  "code": "disability_4a_age_standardised-001",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "are",
+                  "legend_str_3": "disabled under the equality act: day-to-day activities limited a lot"
+                },
+                {
+                  "name": "Disabled under the Equality Act: Day-to-day activities limited a little",
+                  "slug": "disabled-under-the-equality-act-day-to-day-activities-limited-a-little",
+                  "code": "disability_4a_age_standardised-002",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "are",
+                  "legend_str_3": "disabled under the equality act: day-to-day activities limited a little"
+                },
+                {
+                  "name": "Not disabled under the Equality Act",
+                  "slug": "not-disabled-under-the-equality-act",
+                  "code": "disability_4a_age_standardised-003",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "are",
+                  "legend_str_3": "not disabled under the equality act"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "General health",
           "code": "health_in_general",
           "slug": "general-health",
@@ -67,13 +121,16 @@
           "long_desc": "A person's assessment of the general state of their health from very good to very bad. This assessment is not based on a person's health over any specified period of time.",
           "units": "Household",
           "topic_code": "HUC",
-          "caveat_text": "Figures for this variable are age standardised.",
+          "caveat_text": "Values are not age-standardised, so do not account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
           "classifications": [
             {
               "code": "health_in_general",
               "slug": "health-in-general",
               "desc": "General health (6 categories)",
               "available_geotypes": [
+                "oa",
+                "msoa",
                 "lad"
               ],
               "choropleth_default": true,
@@ -126,6 +183,73 @@
           ]
         },
         {
+          "name": "General health (age-standardised)",
+          "code": "health_in_general_age_standardised",
+          "slug": "general-health-age-standardised",
+          "desc": "How people rate their general health.",
+          "long_desc": "A person's assessment of the general state of their health from very good to very bad. This assessment is not based on a person's health over any specified period of time.",
+          "units": "Household",
+          "topic_code": "HUC",
+          "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+          "classifications": [
+            {
+              "code": "health_in_general",
+              "slug": "health-in-general",
+              "desc": "General health (6 categories)",
+              "available_geotypes": [
+                "lad"
+              ],
+              "choropleth_default": true,
+              "dot_density_default": true,
+              "comparison_2011_data_available": true,
+              "data_download": "https://www.ons.gov.uk/datasets/TS037/editions/2021",
+              "categories": [
+                {
+                  "name": "Very good health",
+                  "slug": "very-good-health",
+                  "code": "health_in_general_age_standardised-001",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "very good health"
+                },
+                {
+                  "name": "Good health",
+                  "slug": "good-health",
+                  "code": "health_in_general_age_standardised-002",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "good health"
+                },
+                {
+                  "name": "Fair health",
+                  "slug": "fair-health",
+                  "code": "health_in_general_age_standardised-003",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "fair health"
+                },
+                {
+                  "name": "Bad health",
+                  "slug": "bad-health",
+                  "code": "health_in_general_age_standardised-004",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "bad health"
+                },
+                {
+                  "name": "Very bad health",
+                  "slug": "very-bad-health",
+                  "code": "health_in_general_age_standardised-005",
+                  "legend_str_1": "of people in {location}",
+                  "legend_str_2": "have",
+                  "legend_str_3": "very bad health"
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "Provision of unpaid care",
           "code": "is_carer",
           "slug": "provision-of-unpaid-care",
@@ -133,13 +257,16 @@
           "long_desc": "An unpaid carer may look after, give help or support to anyone who has long-term physical or mental ill-health conditions, illness or problems related to old age.  \n\nThis does not include any activities as part of paid employment. \n\nThis help can be within or outside of the carer's household.",
           "units": "Person",
           "topic_code": "HUC",
-          "caveat_text": "Figures for this variable are age standardised.",
+          "caveat_text": "Values are not age-standardised, so do not account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
           "classifications": [
             {
               "code": "is_carer_5a",
               "slug": "is-carer-5a",
               "desc": "Unpaid care (5 categories)",
               "available_geotypes": [
+                "oa",
+                "msoa",
                 "lad"
               ],
               "choropleth_default": true,
@@ -174,6 +301,64 @@
                   "name": "Provides 50 or more hours unpaid care a week",
                   "slug": "provides-50-or-more-hours-unpaid-care-a-week",
                   "code": "is_carer_5a-004",
+                  "legend_str_1": "of people aged 5 years and over in {location}",
+                  "legend_str_2": "provide",
+                  "legend_str_3": "50 or more hours unpaid care a week"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Provision of unpaid care (age-standardised)",
+          "code": "is_carer_age_standardised",
+          "slug": "provision-of-unpaid-care-age-standardised",
+          "desc": "People who are unpaid carers.",
+          "long_desc": "An unpaid carer may look after, give help or support to anyone who has long-term physical or mental ill-health conditions, illness or problems related to old age.  \n\nThis does not include any activities as part of paid employment. \n\nThis help can be within or outside of the carer's household.",
+          "units": "Person",
+          "topic_code": "HUC",
+          "caveat_text": "Values are age-standardised to account for differences in population size and age structure.",
+          "caveat_link": "http://www.ons.gov.uk/peoplepopulationandcommunity/healthandsocialcare/healthandwellbeing/methodologies/healthdisabilityandunpaidcarequalityinformationforcensus2021",
+          "classifications": [
+            {
+              "code": "is_carer_5a",
+              "slug": "is-carer-5a",
+              "desc": "Unpaid care (5 categories)",
+              "available_geotypes": [
+                "lad"
+              ],
+              "choropleth_default": true,
+              "dot_density_default": true,
+              "comparison_2011_data_available": true,
+              "categories": [
+                {
+                  "name": "Provides no unpaid care",
+                  "slug": "provides-no-unpaid-care",
+                  "code": "is_carer_5a_age_standardised-001",
+                  "legend_str_1": "of people aged 5 years and over in {location}",
+                  "legend_str_2": "provide",
+                  "legend_str_3": "no unpaid care"
+                },
+                {
+                  "name": "Provides 19 or less hours unpaid care a week",
+                  "slug": "provides-19-or-less-hours-unpaid-care-a-week",
+                  "code": "is_carer_5a_age_standardised-002",
+                  "legend_str_1": "of people aged 5 years and over in {location}",
+                  "legend_str_2": "provide",
+                  "legend_str_3": "19 or less hours unpaid care a week"
+                },
+                {
+                  "name": "Provides 20 to 49 hours unpaid care a week",
+                  "slug": "provides-20-to-49-hours-unpaid-care-a-week",
+                  "code": "is_carer_5a_age_standardised-003",
+                  "legend_str_1": "of people aged 5 years and over in {location}",
+                  "legend_str_2": "provide",
+                  "legend_str_3": "20 to 49 hours unpaid care a week"
+                },
+                {
+                  "name": "Provides 50 or more hours unpaid care a week",
+                  "slug": "provides-50-or-more-hours-unpaid-care-a-week",
+                  "code": "is_carer_5a_age_standardised-004",
                   "legend_str_1": "of people aged 5 years and over in {location}",
                   "legend_str_2": "provide",
                   "legend_str_3": "50 or more hours unpaid care a week"

--- a/scripts/content/output_content_jsons/2021-LAB.json
+++ b/scripts/content/output_content_jsons/2021-LAB.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-LAB-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-MIG.json
+++ b/scripts/content/output_content_jsons/2021-MIG.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-MIG-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-SOGI.json
+++ b/scripts/content/output_content_jsons/2021-SOGI.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-SOGI-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-TTW.json
+++ b/scripts/content/output_content_jsons/2021-TTW.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-TTW-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [

--- a/scripts/content/output_content_jsons/2021-WELSH-SKILLS.json
+++ b/scripts/content/output_content_jsons/2021-WELSH-SKILLS.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-01-11-09-48-45",
+    "created_at": "2023-01-13-13-28-38",
     "release": "2021-WELSH-SKILLS-ar2776-c21ew_metadata-v1-3_cantab_20230104-38"
   },
   "content": [


### PR DESCRIPTION
### What

- add custom age-standardised variants of all huc variables
- update available geotypes for non-age-standardised huc variables
- update content to latest metadata v39

### How to review

- 👀 
- go to 'health' in preview and see how it looks: https://deploy-preview-404--dp-census-atlas.netlify.app/choropleth/health

### Who can review

Anyone