### PR TITLE
use simplified breaksCkmeans files

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,19 +101,18 @@ Example data:
 
 This API represents the "five colours" - otherwise known as the breaks, or "buckets", of the choropleth.
 
-Logically, this is just 6 numbers between 0 and 1. (The output is split into two for historical reasons, with the highest and lowest numbers in a separate array. The property names here can otherwise be ignored).
+This is just 6 numbers between 0 and 1. (The first one is the minimum value for each category, the next five are the upper bounds of each bucket).
 
 Now we know how to colour an area! (We know which bucket its value belongs to.)
 
-    "MSOA": [
+Example data:
+
+    [
+        0.01660255112370925,
         0.14306061085614813,
         0.2033898305084746,
         0.2640757349277529,
         0.33841721742077613,
-        0.5066721412440978
-    ],
-    "MSOA_min_max": [
-        0.01660255112370925,
         0.5066721412440978
     ]
 

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -50,40 +50,18 @@ export const fetchTileData = async (args: { category: Category; geoType: GeoType
 };
 
 /*
-  Fetch json with estimated natural breakpoints (w. ckmeans algorithm) in data for all census category 'categoryCode'
-  divided by total for that category.
+  Fetch json with estimated natural breakpoints (w. ckmeans algorithm) in category data. Breaks include min value for
+  category as first value.
 */
 export const fetchBreaks = async (args: {
   classification: Classification;
   category: Category;
   geoType: GeoType;
 }): Promise<{ breaks: number[] }> => {
-  const url = `${args.category.baseUrl}/breaks/${args.geoType}/${args.category.code}.json`;
+  const url = `${args.category.baseUrl}/breaksCkmeans/${args.geoType}/${args.category.code}.json`;
   const response = await fetch(url);
   const breaksRaw = await response.json();
-  /*
-    breaks json files have legacy format from when it was an API response:
-    e.g.
-    {
-      "KS103EW0002": {
-        "LAD": [
-            0.283667019342937,
-            0.32603232256525966,
-            0.3817375703709814,
-            0.4696799398260561,
-            0.5993594922100404
-        ],
-        "LAD_min_max": [
-            0.21006838234294492,
-            0.5993594922100404
-        ]
-      }
-    }
-  */
-  const breaks = uniqueRoundedClassificationBreaks(args.classification.code, [
-    breaksRaw[args.category.code][`${args.geoType.toUpperCase()}_min_max`][0],
-    ...breaksRaw[args.category.code][args.geoType.toUpperCase()],
-  ]);
+  const breaks = uniqueRoundedClassificationBreaks(args.classification.code, breaksRaw);
   return { breaks };
 };
 


### PR DESCRIPTION
### What

Switch to the simpler version of the ckmeans json files (smaller, easier to process)

### How to review

- 👀 
- compare with [original breaks](https://dp-census-atlas.netlify.app) using [the preview below](https://deploy-preview-412--dp-census-atlas.netlify.app), they should be identical. Some random samples for each topic:
- [original arm](https://dp-census-atlas.netlify.app/choropleth/population/uk-armed-forces-veteran-indicator/uk-armed-forces/previously-served-in-uk-reserve-armed-forces?lad=E06000042) vs [new arm](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/population/uk-armed-forces-veteran-indicator/uk-armed-forces/previously-served-in-uk-reserve-armed-forces?lad=E06000042)
- [original dem](https://dp-census-atlas.netlify.app/choropleth/population/legal-partnership-status/legal-partnership-status-3a/married-or-in-a-registered-civil-partnership?msoa=E02001879) vs [new dem](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/population/legal-partnership-status/legal-partnership-status-3a/married-or-in-a-registered-civil-partnership?msoa=E02001879)
- [original edu](https://dp-census-atlas.netlify.app/choropleth/education/highest-level-of-qualification/highest-qualification-6a/highest-level-of-qualification-apprenticeship) vs [new edu](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/education/highest-level-of-qualification/highest-qualification-6a/highest-level-of-qualification-apprenticeship)
- [original eilr](https://dp-census-atlas.netlify.app/choropleth/identity/national-identity/national-identity-all-4a/one-or-more-uk-identity-only?msoa=E02006853) vs [new eilr](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/identity/national-identity/national-identity-all-4a/one-or-more-uk-identity-only?msoa=E02006853)
- [original hou](https://dp-census-atlas.netlify.app/choropleth/housing/occupancy-rating-for-rooms/occupancy-rating-rooms-6a/occupancy-rating-of-rooms-minus-2-or-less?msoa=E02001133) vs [new hou](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/housing/occupancy-rating-for-rooms/occupancy-rating-rooms-6a/occupancy-rating-of-rooms-minus-2-or-less?msoa=E02001133)
- [original huc](https://dp-census-atlas.netlify.app/choropleth/health/provision-of-unpaid-care-age-standardised/is-carer-5a/provides-19-or-less-hours-unpaid-care-a-week?msoa=E02001133) vs [new huc](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/health/provision-of-unpaid-care-age-standardised/is-carer-5a/provides-19-or-less-hours-unpaid-care-a-week?msoa=E02001133)
- [original lab](https://dp-census-atlas.netlify.app/choropleth/work/industry-current/industry-current-88a/01-crop-and-animal-production-hunting-and-related-service-activities?msoa=E02005775) vs [new lab](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/work/industry-current/industry-current-88a/01-crop-and-animal-production-hunting-and-related-service-activities?msoa=E02005775)
- [original mig](https://dp-census-atlas.netlify.app/choropleth/population/migrant-indicator/migrant-ind/address-one-year-ago-is-the-same-as-the-address-of-enumeration?lad=E08000036) vs [new mig](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/population/migrant-indicator/migrant-ind/address-one-year-ago-is-the-same-as-the-address-of-enumeration?lad=E08000036)
- [originial sogi](https://dp-census-atlas.netlify.app/choropleth/identity/sexual-orientation/sexual-orientation-4a/lesbian-gay-bisexual-or-other-lgb) vs [new sogi](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/identity/sexual-orientation/sexual-orientation-4a/lesbian-gay-bisexual-or-other-lgb)
- [original ttw](https://dp-census-atlas.netlify.app/choropleth/work/distance-travelled-to-work/workplace-travel-4a/less-than-10km?lad=E06000026) vs [new ttw](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/work/distance-travelled-to-work/workplace-travel-4a/less-than-10km?lad=E06000026)
- [original welsh skills](https://dp-census-atlas.netlify.app/choropleth/identity/welsh-language-skills/welsh-skills-all-4b/can-speak-read-or-write-welsh?msoa=W02000009) vs [new welsh skills](https://deploy-preview-412--dp-census-atlas.netlify.app/choropleth/identity/welsh-language-skills/welsh-skills-all-4b/can-speak-read-or-write-welsh?msoa=W02000009)


### Who can review

Anyone