### PR TITLE
use S3 URIs instead of bucket:prefix notation

### DIFF
--- a/scripts/s3sync/storage/location.go
+++ b/scripts/s3sync/storage/location.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"errors"
+	"strings"
+)
+
+// Location is the result of parsing a command line S3 or file location string.
+// When Schem is "s3", Bucket and Prefix will be set.
+// When Scheme is "file", Path will be set.
+type Location struct {
+	Scheme string
+	Bucket string
+	Prefix string
+	Path   string
+}
+
+const (
+	FileScheme = "file"
+	S3Scheme   = "s3"
+	delim      = "://"
+)
+
+// ParseLocation takes a string holding an S3 or file location and returns its components.
+// S3 locations are parsed as s3://bucket/prefix.
+// Anything that doesn't start with "s3://" is a file location.
+// Scheme will be "s3" or "file".
+func ParseLocation(s string) (*Location, error) {
+	// We don't use url.Parse because standard URIs do not handle drive letters or relative paths.
+
+	if strings.HasPrefix(s, S3Scheme+delim) {
+		s = strings.TrimPrefix(s, S3Scheme+delim)
+		bucket, prefix, _ := strings.Cut(s, "/")
+		if bucket == "" {
+			return nil, errors.New("missing bucket in S3 location")
+		}
+		return &Location{
+			Scheme: S3Scheme,
+			Bucket: bucket,
+			Prefix: prefix,
+		}, nil
+	}
+
+	if strings.Contains(s, delim) {
+		return nil, errors.New("only S3 URIs supported")
+	}
+
+	if s == "" {
+		return nil, errors.New("file location cannot be empty")
+	}
+
+	return &Location{
+		Scheme: FileScheme,
+		Path:   s,
+	}, nil
+}

--- a/scripts/s3sync/storage/location_test.go
+++ b/scripts/s3sync/storage/location_test.go
@@ -1,0 +1,91 @@
+package storage
+
+import (
+	"testing"
+)
+
+func Test_ParseLocation_Errors(t *testing.T) {
+	var tests = map[string]string{
+		"missing s3 bucket and prefix": "s3://",
+		"missing s3 bucket":            "s3:///prefix",
+		"file uris not supported":      "file:///path",
+		"other uris not supported":     "http://example.com",
+		"empty file location":          "",
+	}
+
+	for desc, s := range tests {
+		if _, err := ParseLocation(s); err == nil {
+			t.Errorf("%s (%s): expected error", desc, s)
+		}
+	}
+}
+
+func Test_ParseLocaton(t *testing.T) {
+	var tests = map[string]struct {
+		s      string
+		scheme string
+		bucket string
+		prefix string
+		path   string
+	}{
+		"just bucket": {
+			s:      "s3://bucket/",
+			scheme: S3Scheme,
+			bucket: "bucket",
+			prefix: "",
+		},
+		"bucket and prefix": {
+			s:      "s3://bucket/prefix",
+			scheme: S3Scheme,
+			bucket: "bucket",
+			prefix: "prefix",
+		},
+
+		"relative": {
+			s:      "./",
+			scheme: FileScheme,
+			path:   "./",
+		},
+		"absolute": {
+			s:      "/foo",
+			scheme: FileScheme,
+			path:   "/foo",
+		},
+
+		"drive": {
+			s:      "C:",
+			scheme: FileScheme,
+			path:   "C:",
+		},
+		"drive and relative": {
+			s:      `C:dir`,
+			scheme: FileScheme,
+			path:   `C:dir`,
+		},
+		"drive and absolute": {
+			s:      `C:\Users\foo`,
+			scheme: FileScheme,
+			path:   `C:\Users\foo`,
+		},
+	}
+
+	for desc, test := range tests {
+		loc, err := ParseLocation(test.s)
+		if err != nil {
+			t.Errorf("%s (%s): %s", desc, test.s, err)
+			continue
+		}
+		if test.scheme != loc.Scheme {
+			t.Errorf("%s: scheme %q, want %q", desc, loc.Scheme, test.scheme)
+		}
+		if test.bucket != loc.Bucket {
+			t.Errorf("%s: bucket %q, want %q", desc, loc.Bucket, test.bucket)
+		}
+		if test.prefix != loc.Prefix {
+			t.Errorf("%s: prefix %q, want %q", desc, loc.Prefix, test.prefix)
+		}
+		if test.path != loc.Path {
+			t.Errorf("%s: path %q, want %q", desc, loc.Path, test.path)
+		}
+	}
+}


### PR DESCRIPTION
### What

The bucket:prefix notation for S3 locations causes problems with windows paths which can have a drive letter and colon.

This change uses the aws cli notation for S3 locations: s3://bucket[/prefix]