### PR TITLE
include content-type in S3 upload metadata

### DIFF
--- a/scripts/s3sync/storage/s3/s3.go
+++ b/scripts/s3sync/storage/s3/s3.go
@@ -145,10 +145,28 @@ func (s *S3) Create(ctx context.Context, name string, r io.Reader, checksum stri
 		Key:               &key,
 		ChecksumAlgorithm: algo,
 		ChecksumCRC32:     crc32,
-		// ACL: aws.String(s3.BucketCannedACLPublicRead),
+		ContentType:       aws.String(contentType(name)),
 	}
 	_, err := s.uploader.UploadWithContext(ctx, in)
 	return err
+}
+
+// contentType returns the MIME content type based on a file extension.
+// We only use a few extensions right now, so this is ok.
+func contentType(fname string) string {
+	ext := strings.ToLower(path.Ext(fname))
+	switch ext {
+	case ".csv":
+		return "text/csv"
+	case ".geojson":
+		return "application/geo+json"
+	case ".json":
+		return "application/json"
+	case ".txt":
+		return "text/plain; charset=utf-8"
+	default:
+		return "application/octet-stream"
+	}
 }
 
 // Open returns a ReadCloser which can be used to read an object's contents.


### PR DESCRIPTION
### What

s3sync wasn't setting the file content type on upload, so the content type on download was always application/octet-stream.

This change sets a content type based on filename extension. Good enough for what we need now.