### PR TITLE
Feature/mktiles2 optional check duplicate cat names

### DIFF
--- a/scripts/content/label_census_input.py
+++ b/scripts/content/label_census_input.py
@@ -1,0 +1,40 @@
+import csv
+import json
+from pathlib import Path
+import sys
+
+if __name__ == "__main__":
+    input_dir = Path(sys.argv[1])
+    prefix_to_match = sys.argv[2]
+    content_json = sys.argv[3]
+    output_dir = input_dir.joinpath("relabelled")
+
+    with open(content_json, "r") as f:
+        content = json.load(f)
+    classifications = []
+    for vg in content["content"]:
+        for v in vg["variables"]:
+            classifications.extend(v["classifications"])
+
+    for input_csv in input_dir.rglob("*.csv"):
+        file_classification = input_csv.stem.split("_2011_2021_comparison")[0]
+
+        for c in classifications:
+            if file_classification.endswith(c["code"]):
+
+                output_filename = output_dir.joinpath(input_csv.relative_to(input_dir))
+                output_filename.parent.mkdir(parents=True, exist_ok=True)
+
+                with open(input_csv) as fin, open(output_filename, "w") as fout:
+
+                    reader = csv.reader(fin)
+                    writer = csv.writer(fout)
+
+                    header = next(reader)
+                    for cat in c["categories"]:
+                        for i, fieldname in enumerate(header):
+                            if fieldname == prefix_to_match + cat["name"]:
+                                header[i] = cat["code"]
+
+                    writer.writerow(header)
+                    writer.writerows(reader)

--- a/scripts/mktiles/cmd/mktiles2/main.go
+++ b/scripts/mktiles/cmd/mktiles2/main.go
@@ -74,11 +74,15 @@ func main() {
 	log.Printf("found %d categories", len(wantcats))
 
 	//
-	// make cat name to cat code map
+	// make cat name to cat code map (only if matching on names)
 	//
-	namesToCats, err := cont.NamesToCats(*classCode, *catNamePrefix)
-	if err != nil {
-		log.Fatal(err)
+	var namesToCats map[string]string
+	if *doCatNameMatching {
+		var err error
+		namesToCats, err = cont.NamesToCats(*classCode, *catNamePrefix)
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	//


### PR DESCRIPTION
### What

commit ff4f6c84e67bbb2fc46857da9a56cf2272018f52 (HEAD -> feature/mktiles2-optional-check-duplicate-cat-names, origin/feature/mktiles2-optional-check-duplicate-cat-names)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Jan 23 12:57:23 2023 +0000

    add python script to relabel input census data files headers

commit 88efdae5e79c03761e58d2a912c3703db574df6e
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Mon Jan 23 12:55:50 2023 +0000

    mktiles2 duplicate cat names check optional (duplicates can exist in diff vars)

### How to review

👀 

### Who can review

@wavemechanics 