### PR TITLE
SPIKE - shade local max/min (rendered geos only) red/blue

### DIFF
--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -131,7 +131,7 @@ export default {
       // edu is unpublished
       {
         contentJsonUrl: edu.localContentJsonUrl,
-        contentBaseUrl: edu.fakeDataBaseUrl,
+        contentBaseUrl: edu.realDataBaseUrl,
       },
       // eilr is published
       {

--- a/src/map/renderMapViz.ts
+++ b/src/map/renderMapViz.ts
@@ -12,13 +12,40 @@ export const renderMapViz = (map: mapboxgl.Map, data: VizData | undefined) => {
   }
 
   const layer = layers.find((l) => l.name == data.geoType);
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore (queryRenderedFeatures typings appear to be wrong)
+  const renderedGeos = map.queryRenderedFeatures({ layers: [`${data.geoType}-features`] }).map((g) => g.id);
+  let max;
+  let maxGeo;
+  let min;
+  let minGeo;
 
   data.places.forEach((p) => {
+    if (renderedGeos.includes(p.geoCode)) {
+      if (max === undefined) {
+        min = p.categoryValue;
+        minGeo = p.geoCode;
+        max = p.categoryValue;
+        maxGeo = p.geoCode;
+      } else {
+        if (p.categoryValue < min) {
+          min = p.categoryValue;
+          minGeo = p.geoCode;
+        }
+        if (p.categoryValue > max) {
+          max = p.categoryValue;
+          maxGeo = p.geoCode;
+        }
+      }
+    }
     map.setFeatureState(
       { source: layer.name, sourceLayer: layer.sourceLayer, id: p.geoCode },
       { colour: getChoroplethColour(p.categoryValue, data.breaks) },
     );
   });
+
+  map.setFeatureState({ source: layer.name, sourceLayer: layer.sourceLayer, id: minGeo }, { colour: "#FF0000" });
+  map.setFeatureState({ source: layer.name, sourceLayer: layer.sourceLayer, id: maxGeo }, { colour: "#00FF00" });
 };
 
 const getChoroplethColour = (value: number, breaks: number[]) => {


### PR DESCRIPTION
DO NOT MERGE DEMO ONLY

Idea here is to make it easier to see the local max / min for a given census variable - the on-screen geo with the lowest value will be blue, whereas the on-screen geo with the highest value will be red
