### PR TITLE
check both base url + available geotypes filtering change-over-time vars

### DIFF
--- a/src/helpers/contentHelpers.ts
+++ b/src/helpers/contentHelpers.ts
@@ -234,7 +234,10 @@ export const filterVariableGroupsForMapType = (variableGroups: VariableGroup[], 
   if (mapType === "choropleth") {
     return variableGroups;
   }
-  // return only those with classifications that have available change-over-time geographies for change-over-time
+  /* for change-over-time return only those variables with:
+      - a defined base_url_2011_2021_comparison
+      - at least one classification that has a populated comparison_2011_data_available_geotypes
+  */
   if (mapType === "change-over-time") {
     const vgs = variableGroups
       .map((vg) => {
@@ -244,7 +247,7 @@ export const filterVariableGroupsForMapType = (variableGroups: VariableGroup[], 
               (c) =>
                 c.comparison_2011_data_available_geotypes && c.comparison_2011_data_available_geotypes.length !== 0,
             );
-            if (filtClassifications.length > 0) {
+            if (v.base_url_2011_2021_comparison && filtClassifications.length > 0) {
               const filtVariable = { ...v };
               filtVariable.classifications = filtClassifications;
               return filtVariable;


### PR DESCRIPTION
check both base_url_2011_2021_comparison and comparison_2011_data_available_geotypes when filtering content trees for change-over-time maptype. This ensures that unsetting the base_url property turns off the change-over-time maptype feature, as intended.
