### PR TITLE
Feature/change only classifications

### DIFF
--- a/scripts/content/2021-content-spec.json
+++ b/scripts/content/2021-content-spec.json
@@ -37,7 +37,7 @@
                     "desc": "Population density",
                     "available_geotypes": ["oa", "msoa", "lad"],
                     "choropleth_default": true,
-                    "comparison_2011_data_available_geotypes": ["lad"],
+                    "comparison_2011_data_available_geotypes": ["lad", "msoa", "oa"],
                     "data_download": "https://www.nomisweb.co.uk/datasets/c2021ts006",
                     "categories": [
                       {

--- a/scripts/content/2021-content-spec.json
+++ b/scripts/content/2021-content-spec.json
@@ -75,7 +75,41 @@
                 "legal_partnership_status_3a",
                 "legal_partnership_status_6a",
                 "legal_partnership_status"
-              ]
+              ],
+              "classification_category_mode_restrictions": {
+                "legal_partnership_status": {
+                  "legal_partnership_status-002": ["choropleth"],
+                  "legal_partnership_status-003": ["choropleth"],
+                  "legal_partnership_status-004": ["choropleth"]
+                }
+              },
+              "classification_custom_categories": {
+                "legal_partnership_status": [
+                  {
+                    "insert_after": "legal_partnership_status-001",
+                    "categories": [
+                      {
+                        "name": "Married",
+                        "slug": "married",
+                        "code": "legal_partnership_status-002.003",
+                        "legend_str_1": "of people aged 16 years and over in {location}",
+                        "legend_str_2": "are",
+                        "legend_str_3": "married",
+                        "restrict_to_modes": ["change"]
+                      },
+                      {
+                        "name": "In a registered civil partnership",
+                        "slug": "in-a-registered-civil-partnership",
+                        "code": "legal_partnership_status-004.005",
+                        "legend_str_1": "of people aged 16 years and over in {location}",
+                        "legend_str_2": "are",
+                        "legend_str_3": "in a registered civil partnership",
+                        "restrict_to_modes": ["change"]
+                      }
+                    ]
+                  }
+                ]
+              }
             },
             {
               "code": "living_arrangements",
@@ -214,7 +248,12 @@
             },
             {
               "code": "national_identity_detailed",
-              "classifications": ["national_identity_detailed"]
+              "classifications": ["national_identity_detailed"],
+              "classification_category_mode_restrictions": {
+                "national_identity_detailed": {
+                  "national_identity_detailed-041": ["choropleth"]
+                }
+              }
             },
             {
               "code": "religion_tb",
@@ -245,7 +284,12 @@
           "variables": [
             {
               "code": "accommodation_type",
-              "classifications": ["accommodation_type_3a", "accommodation_type_5a", "accommodation_type"]
+              "classifications": ["accommodation_type_3a", "accommodation_type_5a", "accommodation_type"],
+              "classification_category_mode_restrictions": {
+                "accommodation_type": {
+                  "accommodation_type-006": ["choropleth"]
+                }
+              }
             },
             {
               "code": "alternative_address_indicator",
@@ -280,6 +324,11 @@
               "classifications": ["second_address_type_priority"],
               "classification_dropped_categories": {
                 "second_address_type_priority": ["Second address type not specified"]
+              },
+              "classification_category_mode_restrictions": {
+                "second_address_type_priority": {
+                  "second_address_type_priority-007": ["choropleth"]
+                }
               }
             }
           ]

--- a/scripts/content/input_metadata_files/classification_data_available_geotypes.csv
+++ b/scripts/content/input_metadata_files/classification_data_available_geotypes.csv
@@ -40,7 +40,7 @@ Identity,2021-SOGI,sexual_orientation,sexual_orientation_4a,"msoa,lad",
 Identity,2021-SOGI,sexual_orientation,sexual_orientation_6a,"msoa,lad",
 Identity,2021-SOGI,sexual_orientation,sexual_orientation_9a,lad,
 Population,2021-ARM,uk_armed_forces,uk_armed_forces,"msoa,lad",
-Population,2021-DEM,hh_deprivation,hh_deprivation,"oa,msoa,lad","oa,msoa,lad"
+Population,2021-DEM,hh_deprivation,hh_deprivation,"oa,msoa,lad",
 Population,2021-DEM,hh_family_composition,hh_family_composition_15a,"oa,msoa,lad",lad
 Population,2021-DEM,hh_family_composition,hh_family_composition_4a,"oa,msoa,lad","oa,msoa,lad"
 Population,2021-DEM,hh_size,hh_size_5a,"oa,msoa,lad","oa,msoa,lad"
@@ -58,7 +58,7 @@ Population,2021-DEM,resident_age,resident_age_8c,"msoa,lad","msoa,lad"
 Population,2021-DEM,sex,sex,"oa,msoa,lad","oa,msoa,lad"
 Population,2021-MIG,age_arrival_uk,age_arrival_uk_18a,"oa,msoa,lad",lad
 Population,2021-MIG,country_of_birth,country_of_birth_12a,"oa,msoa,lad",lad
-Population,2021-MIG,country_of_birth,country_of_birth_3a,lad,lad
+Population,2021-MIG,country_of_birth,country_of_birth_3a,lad,"oa,msoa,lad"
 Population,2021-MIG,country_of_birth,country_of_birth_60a,lad,lad
 Population,2021-MIG,country_of_birth,country_of_birth_8a,lad,lad
 Population,2021-MIG,migrant_ind,migrant_ind,"oa,msoa,lad","oa,msoa,lad"
@@ -68,8 +68,8 @@ Population,2021-MIG,passports_all,passports_all_27a,"oa,msoa,lad",lad
 Population,2021-MIG,passports_all,passports_all_4a,"oa,msoa,lad","msoa,lad"
 Population,2021-MIG,passports_all,passports_all_52a,"msoa,lad",lad
 Population,2021-MIG,residence_length,residence_length_6b,"oa,msoa,lad","oa,msoa,lad"
-Population,2021-MIG,year_arrival_uk,year_arrival_uk,"oa,msoa,lad",lad
-Population,2021-MIG,year_arrival_uk,year_arrival_uk_6a,"oa,msoa,lad","oa,msoa,lad"
+Population,2021-MIG,year_arrival_uk,year_arrival_uk,"oa,msoa,lad",
+Population,2021-MIG,year_arrival_uk,year_arrival_uk_6a,"oa,msoa,lad",
 Work,2021-LAB,economic_activity,economic_activity_status_10a,"oa,msoa,lad",lad
 Work,2021-LAB,economic_activity,economic_activity_status_3a,"oa,msoa,lad",
 Work,2021-LAB,economic_activity,economic_activity_status_4a,"oa,msoa,lad","oa,msoa,lad"

--- a/scripts/content/input_metadata_files/variable_tile_data_base_urls.csv
+++ b/scripts/content/input_metadata_files/variable_tile_data_base_urls.csv
@@ -25,7 +25,7 @@ Identity,2021-WELSH-SKILLS,welsh_skills_speak,https://ons-dp-prod-census-maps-we
 Identity,2021-SOGI,gender_identity,https://ons-dp-prod-census-maps-sogi.s3.eu-west-2.amazonaws.com,,,
 Identity,2021-SOGI,sexual_orientation,https://ons-dp-prod-census-maps-sogi.s3.eu-west-2.amazonaws.com,,,
 Population,2021-ARM,uk_armed_forces,https://ons-dp-prod-census-maps-arm.s3.eu-west-2.amazonaws.com,,,
-Population,2021-DEM,hh_deprivation,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
+Population,2021-DEM,hh_deprivation,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,
 Population,2021-DEM,hh_family_composition,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
 Population,2021-DEM,hh_size,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
 Population,2021-DEM,legal_partnership_status,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
@@ -37,7 +37,7 @@ Population,2021-MIG,country_of_birth,https://ons-dp-prod-census-maps-dem-mig.s3.
 Population,2021-MIG,migrant_ind,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
 Population,2021-MIG,passports_all,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
 Population,2021-MIG,residence_length,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
-Population,2021-MIG,year_arrival_uk,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
+Population,2021-MIG,year_arrival_uk,https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com,,,
 Work,2021-LAB,economic_activity,https://ons-dp-prod-census-maps-lab.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
 Work,2021-LAB,has_ever_worked,https://ons-dp-prod-census-maps-lab.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison
 Work,2021-LAB,hours_per_week_worked,https://ons-dp-prod-census-maps-lab.s3.eu-west-2.amazonaws.com,,,https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison

--- a/scripts/content/models/category.py
+++ b/scripts/content/models/category.py
@@ -15,6 +15,7 @@ class CensusCategory:
     legend_str_1: str
     legend_str_2: str
     legend_str_3: str
+    restrict_to_modes: list[str]
     _classification_code: str = ""
     _category_code: str = ""
 
@@ -39,7 +40,7 @@ class CensusCategory:
 
     def to_jsonable(self) -> dict:
         """Category in json-friendly form."""
-        return {
+        output_params = {
             "name": self.name,
             "slug": self.slug,
             "code": self.code,
@@ -47,6 +48,11 @@ class CensusCategory:
             "legend_str_2": self.legend_str_2,
             "legend_str_3": self.legend_str_3,
         }
+
+        if self.restrict_to_modes:
+            output_params["restrict_to_modes"] = self.restrict_to_modes
+
+        return output_params
 
 
 def category_from_content_json(content_json: dict) -> CensusCategory:
@@ -58,6 +64,7 @@ def category_from_content_json(content_json: dict) -> CensusCategory:
         legend_str_1=content_json["legend_str_1"],
         legend_str_2=content_json["legend_str_2"],
         legend_str_3=content_json["legend_str_3"],
+        restrict_to_modes=content_json.get("restrict_to_modes", []),
     )
 
 
@@ -95,6 +102,7 @@ def categories_from_metadata(category_csv: Path or str, legend_strs_csv: Path or
                     legend_str_1="",
                     legend_str_2="",
                     legend_str_3="",
+                    restrict_to_modes=[],
                     _classification_code=csv_row["Classification_Mnemonic"],
                     _category_code=csv_row["Category_Code"],
                 )

--- a/src/data/staticContentJsons/2021-MASTER.json
+++ b/src/data/staticContentJsons/2021-MASTER.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-02-21-15-04-49",
+    "created_at": "2023-02-22-14-57-36",
     "release": "2021-MASTER-ar2776-c21ew_metadata-v1-3_cantab_20230209-44",
     "additional_content_jsons": [
       {
@@ -96,7 +96,9 @@
               ],
               "choropleth_default": true,
               "comparison_2011_data_available_geotypes": [
-                "lad"
+                "lad",
+                "msoa",
+                "oa"
               ],
               "data_download": "https://www.nomisweb.co.uk/datasets/c2021ts006",
               "categories": [
@@ -121,7 +123,6 @@
           "units": "Household",
           "topic_code": "DEM",
           "base_url_2021": "https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com",
-          "base_url_2011_2021_comparison_dev_override": "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison",
           "classifications": [
             {
               "code": "hh_deprivation",
@@ -134,11 +135,6 @@
               ],
               "choropleth_default": true,
               "dot_density_default": true,
-              "comparison_2011_data_available_geotypes": [
-                "oa",
-                "msoa",
-                "lad"
-              ],
               "data_download": "https://www.ons.gov.uk/datasets/TS011/editions/2021",
               "categories": [
                 {
@@ -2201,6 +2197,8 @@
               "choropleth_default": true,
               "dot_density_default": true,
               "comparison_2011_data_available_geotypes": [
+                "oa",
+                "msoa",
                 "lad"
               ],
               "data_download": "https://www.ons.gov.uk/datasets/TS004/editions/2021",
@@ -3998,7 +3996,6 @@
           "units": "Person",
           "topic_code": "MIG",
           "base_url_2021": "https://ons-dp-prod-census-maps-dem-mig.s3.eu-west-2.amazonaws.com",
-          "base_url_2011_2021_comparison_dev_override": "https://ons-dp-sandbox-atlas-data.s3.eu-west-2.amazonaws.com/FAKE/2011-2021-comparison",
           "classifications": [
             {
               "code": "year_arrival_uk_6a",
@@ -4011,11 +4008,6 @@
               ],
               "choropleth_default": true,
               "dot_density_default": true,
-              "comparison_2011_data_available_geotypes": [
-                "oa",
-                "msoa",
-                "lad"
-              ],
               "data_download": "https://www.ons.gov.uk/datasets/TS015/editions/2021",
               "categories": [
                 {
@@ -4067,9 +4059,6 @@
               "available_geotypes": [
                 "oa",
                 "msoa",
-                "lad"
-              ],
-              "comparison_2011_data_available_geotypes": [
                 "lad"
               ],
               "data_download": "https://www.ons.gov.uk/datasets/TS015/editions/2021",

--- a/src/data/staticContentJsons/2021-MASTER.json
+++ b/src/data/staticContentJsons/2021-MASTER.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-02-20-08-40-46",
+    "created_at": "2023-02-21-15-04-49",
     "release": "2021-MASTER-ar2776-c21ew_metadata-v1-3_cantab_20230209-44",
     "additional_content_jsons": [
       {
@@ -641,12 +641,37 @@
                   "legend_str_3": "never married and never registered a civil partnership"
                 },
                 {
+                  "name": "Married",
+                  "slug": "married",
+                  "code": "legal_partnership_status-002.003",
+                  "legend_str_1": "of people aged 16 years and over in {location}",
+                  "legend_str_2": "are",
+                  "legend_str_3": "married",
+                  "restrict_to_modes": [
+                    "change"
+                  ]
+                },
+                {
+                  "name": "In a registered civil partnership",
+                  "slug": "in-a-registered-civil-partnership",
+                  "code": "legal_partnership_status-004.005",
+                  "legend_str_1": "of people aged 16 years and over in {location}",
+                  "legend_str_2": "are",
+                  "legend_str_3": "in a registered civil partnership",
+                  "restrict_to_modes": [
+                    "change"
+                  ]
+                },
+                {
                   "name": "Married: Opposite sex",
                   "slug": "married-opposite-sex",
                   "code": "legal_partnership_status-002",
                   "legend_str_1": "of people aged 16 years and over in {location}",
                   "legend_str_2": "are",
-                  "legend_str_3": "married to the opposite sex"
+                  "legend_str_3": "married to the opposite sex",
+                  "restrict_to_modes": [
+                    "choropleth"
+                  ]
                 },
                 {
                   "name": "Married: Same sex",
@@ -654,7 +679,10 @@
                   "code": "legal_partnership_status-003",
                   "legend_str_1": "of people aged 16 years and over in {location}",
                   "legend_str_2": "are",
-                  "legend_str_3": "married to the same sex"
+                  "legend_str_3": "married to the same sex",
+                  "restrict_to_modes": [
+                    "choropleth"
+                  ]
                 },
                 {
                   "name": "In a registered civil partnership: Opposite sex",
@@ -662,7 +690,10 @@
                   "code": "legal_partnership_status-004",
                   "legend_str_1": "of people aged 16 years and over in {location}",
                   "legend_str_2": "are",
-                  "legend_str_3": "in a registered civil partnership with the opposite sex"
+                  "legend_str_3": "in a registered civil partnership with the opposite sex",
+                  "restrict_to_modes": [
+                    "choropleth"
+                  ]
                 },
                 {
                   "name": "In a registered civil partnership: Same sex",
@@ -6617,7 +6648,10 @@
                   "code": "national_identity_detailed-041",
                   "legend_str_1": "of people in {location}",
                   "legend_str_2": "identify as",
-                  "legend_str_3": "Kurdish"
+                  "legend_str_3": "Kurdish",
+                  "restrict_to_modes": [
+                    "choropleth"
+                  ]
                 },
                 {
                   "name": "Other identity only: Middle Eastern and Asian: Middle Eastern: Iranian",
@@ -7700,7 +7734,10 @@
                   "code": "accommodation_type-006",
                   "legend_str_1": "of households in {location}",
                   "legend_str_2": "are",
-                  "legend_str_3": "part of another converted building, for example, former school, church or warehouse"
+                  "legend_str_3": "part of another converted building, for example, former school, church or warehouse",
+                  "restrict_to_modes": [
+                    "choropleth"
+                  ]
                 },
                 {
                   "name": "In a commercial building, for example, in an office building, hotel or over a shop",
@@ -8461,7 +8498,10 @@
                   "code": "second_address_type_priority-007",
                   "legend_str_1": "of people in {location}'s second address",
                   "legend_str_2": "is",
-                  "legend_str_3": "a partner's address"
+                  "legend_str_3": "a partner's address",
+                  "restrict_to_modes": [
+                    "choropleth"
+                  ]
                 },
                 {
                   "name": "Other",

--- a/src/helpers/contentHelpers.ts
+++ b/src/helpers/contentHelpers.ts
@@ -230,41 +230,73 @@ export const sortVariableGroupVariables = (variableGroups: VariableGroup[]) => {
 };
 
 const filterVariableGroupsForMode = (variableGroups: VariableGroup[], mode: Mode) => {
-  switch (mode) {
-    case "choropleth": {
-      // return everything for choropleth
-      return variableGroups;
-    }
-    case "change": {
-      // return only those with classifications that have available change-over-time geographies
-      const vgs = variableGroups
-        .map((vg) => {
-          const filtVariables = vg.variables
-            .map((v) => {
-              const filtClassifications = v.classifications.filter(
-                (c) =>
-                  c.comparison_2011_data_available_geotypes && c.comparison_2011_data_available_geotypes.length > 0,
-              );
-              if (v.base_url_2011_2021_comparison && filtClassifications.length > 0) {
-                const filtVariable = { ...v };
-                filtVariable.classifications = filtClassifications;
-                return filtVariable;
+  return variableGroups
+    .map((vg) => {
+      const filtVariables = vg.variables
+        .map((v) => {
+          const filtClassifications = v.classifications
+            .map((cl) => {
+              // filter categories to those that either DO NOT have a defined 'restrict_to_modes' array, OR have one
+              // that includes the current mode
+              const filtCategories = cl.categories.filter((cat) => {
+                return !cat.restrict_to_modes || cat.restrict_to_modes.includes(mode);
+              });
+              if (filtCategories.length > 0) {
+                // additional mode-dependent filtering goes here
+                const filtClassification = { ...cl };
+                filtClassification.categories = filtCategories;
+                switch (mode) {
+                  // no constraints on choropleth classifications
+                  case "choropleth": {
+                    return filtClassification;
+                  }
+                  // change classifications must have comparison_2011_data_available_geotypes defined
+                  case "change": {
+                    if (
+                      cl.comparison_2011_data_available_geotypes &&
+                      cl.comparison_2011_data_available_geotypes.length > 0
+                    ) {
+                      return filtClassification;
+                    }
+                    break;
+                  }
+                  default: {
+                    return never(mode);
+                  }
+                }
               }
             })
-            .filter((v) => v);
-          if (filtVariables.length > 0) {
-            const filtVariableGroup = { ...vg };
-            filtVariableGroup.variables = filtVariables;
-            return filtVariableGroup;
+            .filter((c) => c);
+          if (filtClassifications.length > 0) {
+            const filtVariable = { ...v };
+            filtVariable.classifications = filtClassifications;
+            // additional mode-dependent filtering goes here
+            switch (mode) {
+              // no constraints on choropleth variables
+              case "choropleth": {
+                return filtVariable;
+              }
+              // change variables must have base_url_2011_2021_comparison defined
+              case "change": {
+                if (v.base_url_2011_2021_comparison) {
+                  return filtVariable;
+                }
+                break;
+              }
+              default: {
+                return never(mode);
+              }
+            }
           }
         })
-        .filter((vg) => vg);
-      return vgs;
-    }
-    default: {
-      return never(mode);
-    }
-  }
+        .filter((v) => v);
+      if (filtVariables.length > 0) {
+        const filtVariableGroup = { ...vg };
+        filtVariableGroup.variables = filtVariables;
+        return filtVariableGroup;
+      }
+    })
+    .filter((vg) => vg);
 };
 
 export const getDataBaseUrlsForVariable = (variable: Variable): Record<Mode, string> => {
@@ -291,4 +323,5 @@ export const getAvailableModesForClassification = (
 
 export const internal = {
   mergeVariableGroups,
+  filterVariableGroupsForMode,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export type Category = {
   legend_str_1: string;
   legend_str_2: string;
   legend_str_3: string;
+  restrict_to_modes: Mode[];
 };
 export type VariableData = { [catCode: string]: { count: number; total: number; percentage: number } };
 


### PR DESCRIPTION
commit 0fe3dc067b4058c9a2117d94055eb6ea6fbc1c37 (HEAD -> feature/change-only-classifications, origin/feature/change-only-classifications)
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Feb 21 15:37:09 2023 +0000

    update change data availability

commit 8c56f70fd90c9f83305d6c7fc15f0c190ca3d98f
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Feb 21 15:06:43 2023 +0000

    implement custom cats and mode restrictions in make_content_jsons

commit dc568604f5a855101eaccec5586f97a160b3f6e3
Author: Vivian Allen <vivian.allen@methods.co.uk>
Date:   Tue Feb 21 10:41:08 2023 +0000

    Support mode-specific categories in content

    - Optional category property, 'restrict_to_modes' (array of modes)
    added. When present, this will mean that this category will ONLY
    appear in the modes specified. This change needed to allow
    differences in classification categories for change data, as things
    are not always directly comparible 2011 -> 2021