### PR TITLE
fix available geotypes for choropleth alaising those for change

### DIFF
--- a/src/stores/selected.ts
+++ b/src/stores/selected.ts
@@ -8,8 +8,14 @@ export const selected = asyncDerived([geography, viz], async ([$geography, $viz]
   if (!$geography) {
     return undefined;
   }
-
-  const dataAvailableForClassification = $viz?.params?.classification?.available_geotypes?.includes($geography.geoType);
+  let dataAvailableForClassification;
+  if ($viz?.params?.mode === "change") {
+    dataAvailableForClassification = () =>
+      $viz?.params?.classification?.comparison_2011_data_available_geotypes?.includes($geography.geoType);
+  } else {
+    dataAvailableForClassification = () =>
+      $viz?.params?.classification?.available_geotypes?.includes($geography.geoType);
+  }
 
   if (!$viz || $geography.geoType === "ew" || !dataAvailableForClassification) {
     return {

--- a/src/stores/viz.ts
+++ b/src/stores/viz.ts
@@ -8,7 +8,13 @@ import { getDataBaseUrlForVariable } from "../helpers/contentHelpers";
  * A Svelte store containing all the data we need in order to show a vizualisation.
  * */
 export const viz = asyncDerived([params, viewport], async ([$params, $viewport]) => {
-  const dataAvailableForClassification = () => $params?.classification?.available_geotypes.includes($viewport.geoType);
+  let dataAvailableForClassification;
+  if ($params?.mode === "change") {
+    dataAvailableForClassification = () =>
+      $params?.classification?.comparison_2011_data_available_geotypes.includes($viewport.geoType);
+  } else {
+    dataAvailableForClassification = () => $params?.classification?.available_geotypes.includes($viewport.geoType);
+  }
 
   if (!$params?.category || !viewport || !dataAvailableForClassification()) {
     return undefined;


### PR DESCRIPTION
### What

- in viz.ts and selected.ts store-populating code, the available_geotypes for choropleth were being used for change. This led to crashes when change geotypes included geotypes not available in choropleth.

### How to review
- 👀 
- navigate to [country of birth 3a in the develop netlify instance](https://dp-census-atlas.netlify.app/change/population/country-of-birth/country-of-birth-3a/born-in-the-uk) then zoom in to msoa. The app should crash, as it will think MSOA is not available (this is because it is looking at the avilable geotypes for choropleth data, not for change)
- navigate to the same place on the preview, issue should be fixed
- 
### Who can review

Anyone