### PR TITLE
refactor redirects for mode + add redirects for change-specific cats

### DIFF
--- a/scripts/content/2021-content-spec.json
+++ b/scripts/content/2021-content-spec.json
@@ -80,7 +80,8 @@
                 "legal_partnership_status": {
                   "legal_partnership_status-002": ["choropleth"],
                   "legal_partnership_status-003": ["choropleth"],
-                  "legal_partnership_status-004": ["choropleth"]
+                  "legal_partnership_status-004": ["choropleth"],
+                  "legal_partnership_status-005": ["choropleth"]
                 }
               },
               "classification_custom_categories": {

--- a/src/data/staticContentJsons/2021-MASTER.json
+++ b/src/data/staticContentJsons/2021-MASTER.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "created_at": "2023-02-22-14-57-36",
+    "created_at": "2023-02-23-11-19-45",
     "release": "2021-MASTER-ar2776-c21ew_metadata-v1-3_cantab_20230209-44",
     "additional_content_jsons": [
       {
@@ -697,7 +697,10 @@
                   "code": "legal_partnership_status-005",
                   "legend_str_1": "of people aged 16 years and over in {location}",
                   "legend_str_2": "are",
-                  "legend_str_3": "in a registered civil partnership with the same sex"
+                  "legend_str_3": "in a registered civil partnership with the same sex",
+                  "restrict_to_modes": [
+                    "choropleth"
+                  ]
                 },
                 {
                   "name": "Separated, but still married",

--- a/src/redirects.ts
+++ b/src/redirects.ts
@@ -1,8 +1,21 @@
 import { redirect } from "@sveltejs/kit";
 
+const isRedirectMatch = (urlPathIn: string, urlPathRedirect: string): boolean => {
+  // match if the split components of urlPathIn match their equivalents in urlPathRedirect
+  const urlPathInComponents = urlPathIn.split("/");
+  const urlPathRedirectComponents = urlPathRedirect.split("/");
+  for (const [i, c] of urlPathRedirectComponents.entries()) {
+    if (urlPathInComponents[i] != c) {
+      return false;
+    }
+  }
+  return true;
+};
+
 export const redirectIfNecessary = (url: URL) => {
-  const match = redirects.find((r) => url.pathname.includes(r.old));
+  const match = redirects.find((r) => isRedirectMatch(url.pathname, r.old));
   if (match) {
+    console.log(match);
     const location = new URL(url);
     location.pathname = url.pathname.replace(match.old, match.new);
     throw redirect(301, location.toString());
@@ -12,6 +25,42 @@ export const redirectIfNecessary = (url: URL) => {
 // add redirects here
 // let's try to keep them in alphabetical order (by the old URL!)
 export const redirects = [
+  {
+    old: "/change/housing/accommodation-type/accommodation-type/part-of-another-converted-building-for-example-former-school-church-or-warehouse",
+    new: "/change/housing/accommodation-type/accommodation-type/in-a-commercial-building-for-example-in-an-office-building-hotel-or-over-a-shop",
+  },
+  {
+    old: "/change/housing/second-address-type/second-address-type-priority/partner-s-address",
+    new: "/change/housing/second-address-type/second-address-type-priority/other",
+  },
+  {
+    old: "/change/identity/national-identity-detailed/national-identity-detailed/other-identity-only-middle-eastern-and-asian-middle-eastern-kurdish",
+    new: "/change/identity/national-identity-detailed/national-identity-detailed/other-identity-only-middle-eastern-and-asian-middle-eastern-other-middle-eastern",
+  },
+  {
+    old: "/change/population/legal-partnership-status/legal-partnership-status/in-a-registered-civil-partnership-opposite-sex",
+    new: "/change/population/legal-partnership-status/legal-partnership-status/in-a-registered-civil-partnership",
+  },
+  {
+    old: "/change/population/legal-partnership-status/legal-partnership-status/in-a-registered-civil-partnership-same-sex",
+    new: "/change/population/legal-partnership-status/legal-partnership-status/in-a-registered-civil-partnership",
+  },
+  {
+    old: "/choropleth/population/legal-partnership-status/legal-partnership-status/in-a-registered-civil-partnership",
+    new: "/choropleth/population/legal-partnership-status/legal-partnership-status/in-a-registered-civil-partnership-same-sex",
+  },
+  {
+    old: "/change/population/legal-partnership-status/legal-partnership-status/married-opposite-sex",
+    new: "/change/population/legal-partnership-status/legal-partnership-status/married",
+  },
+  {
+    old: "/change/population/legal-partnership-status/legal-partnership-status/married-same-sex",
+    new: "/change/population/legal-partnership-status/legal-partnership-status/married",
+  },
+  {
+    old: "/choropleth/population/legal-partnership-status/legal-partnership-status/married",
+    new: "/choropleth/population/legal-partnership-status/legal-partnership-status/married-opposite-sex",
+  },
   {
     old: "/population/household-composition/hh-family-composition-4a/multiple-family-household",
     new: "/population/household-composition/hh-family-composition-4a/other-household-types",


### PR DESCRIPTION
### What

Fix mis-matches between choropleth and change categories with redirects. e.g.  change/legal_partnership_status married (same sex) and married (opposite sex) both redirect to change/legal_parternship_status/married

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
