### PR TITLE
refactor for new 9-point change-over-time colour scale

### DIFF
--- a/src/helpers/choroplethHelpers.ts
+++ b/src/helpers/choroplethHelpers.ts
@@ -3,10 +3,8 @@ import { never } from "../util/typeUtil";
 
 export const colours = {
   standard: ["#CDE594", "#80C6A3", "#1F9EB7", "#186290", "#080C54"] as StringQuintuple,
-  neg: ["#007590", "#538d9e", "#81a6ac", "#abbfbb", "#d5d9c9"] as StringQuintuple,
-  pos: ["#fbd0af", "#f5ab89", "#eb8665", "#de6041", "#ce321f"] as StringQuintuple,
-  neutral: "#fef4d7",
-  noData: "#808B96",
+  neg: ["#ce321f", "#e16a4a", "#f09977", "#fac6a6", "#fef4d7"] as StringQuintuple,
+  pos: ["#fef4d7", "#cad3c5", "#96b3b3", "#5f93a2", "#007590"] as StringQuintuple,
 };
 
 export const getColours = (mode: Mode, breaks: number[]): StringQuintuple => {
@@ -20,7 +18,7 @@ export const getColours = (mode: Mode, breaks: number[]): StringQuintuple => {
   }
 };
 
-export const getChangeColours = (breaks: number[]): [string, string, string, string, string] => {
+export const getChangeColours = (breaks: number[]): StringQuintuple => {
   let result: string[];
 
   // simple cases, all positive or all negative
@@ -40,10 +38,15 @@ export const getChangeColours = (breaks: number[]): [string, string, string, str
     const nBreaksResidual = nBreaksWant - nBreaksGot;
     nBreaksAboveZero += nBreaksResidual;
 
-    // NB avoid issue where slicing with zero index includes ALL neg or pos colors when there should be none
-    const negColours = nBreaksBelowZero > 0 ? colours.neg.slice(nBreaksBelowZero * -1) : [];
-    const posColours = nBreaksAboveZero > 0 ? colours.pos.slice(0, nBreaksAboveZero) : [];
-    result = [...negColours, colours.neutral, ...posColours];
+    // remove the first and last color from neg and pos to make the neutral color
+    const mixedNeutral = colours.pos[0];
+    const mixedNeg = colours.neg.slice(0, -1);
+    const mixedPos = colours.pos.slice(1);
+
+    // NB avoid issue where slicing with zero index includes ALL neg or pos colors when there should be none.
+    const negColours = nBreaksBelowZero > 0 ? mixedNeg.slice(nBreaksBelowZero * -1) : [];
+    const posColours = nBreaksAboveZero > 0 ? mixedPos.slice(0, nBreaksAboveZero) : [];
+    result = [...negColours, mixedNeutral, ...posColours];
   }
 
   return [result[0], result[1], result[2], result[3], result[4]];

--- a/src/helpers/choroplethHelpers.ts.test.ts
+++ b/src/helpers/choroplethHelpers.ts.test.ts
@@ -25,37 +25,35 @@ describe("getChangeOverTimeColours", () => {
     expect(returned).toEqual(colours.neg);
     expect(returned.length).toEqual(5);
   });
-  test("returns neutral + positive colours when first break crosses zero", () => {
+  test("returns positive colours when first break crosses zero", () => {
     const breaksPlusMin = [-1, 2, 3, 4, 5, 6];
-    const expectedColours = [colours.neutral, ...colours.pos.slice(0, 4)];
     const returned = getChangeColours(breaksPlusMin);
-    expect(returned).toEqual(expectedColours);
+    expect(returned).toEqual(colours.pos);
     expect(returned.length).toEqual(5);
   });
-  test("returns negative colours + neutral when last break crosses zero", () => {
+  test("returns negative colours when last break crosses zero", () => {
     const breaksPlusMin = [-6, -5, -4, -3, -2, 1];
-    const expectedColours = [...colours.neg.slice(-4), colours.neutral];
     const returned = getChangeColours(breaksPlusMin);
-    expect(returned).toEqual(expectedColours);
+    expect(returned).toEqual(colours.neg);
     expect(returned.length).toEqual(5);
   });
   test("returns mixed colors when breaksPlusMin cross zero, positive-weighted", () => {
     const breaksPlusMin = [-2, -1, 1, 2, 3, 4];
-    const expectedColours = [...colours.neg.slice(-1), colours.neutral, ...colours.pos.slice(0, 3)];
+    const expectedColours = [...colours.neg.slice(-2, -1), ...colours.pos.slice(0, 4)];
     const returned = getChangeColours(breaksPlusMin);
     expect(returned).toEqual(expectedColours);
     expect(returned.length).toEqual(5);
   });
   test("returns mixed colors when breaksPlusMin cross zero, negative-weighted", () => {
     const breaksPlusMin = [-4, -3, -2, -1, 1, 2];
-    const expectedColours = [...colours.neg.slice(-3), colours.neutral, ...colours.pos.slice(0, 1)];
+    const expectedColours = [...colours.neg.slice(-4), ...colours.pos.slice(1, 2)];
     const returned = getChangeColours(breaksPlusMin);
     expect(returned).toEqual(expectedColours);
     expect(returned.length).toEqual(5);
   });
   test("returns positive-padded mixed colors when breaksPlusMin cross zero and n breaks < 5", () => {
     const breaksPlusMin = [-2, -1, 1, 2];
-    const expectedColours = [...colours.neg.slice(-1), colours.neutral, ...colours.pos.slice(0, 3)];
+    const expectedColours = [...colours.neg.slice(-2, -1), ...colours.pos.slice(0, 4)];
     const returned = getChangeColours(breaksPlusMin);
     expect(returned).toEqual(expectedColours);
     expect(returned.length).toEqual(5);

--- a/src/map/renderMapViz.ts
+++ b/src/map/renderMapViz.ts
@@ -1,7 +1,6 @@
 import { getColours } from "../helpers/choroplethHelpers";
 import type { LoadedGeographies, VizData } from "../types";
 import { layers } from "./layers";
-import { colours as allColours } from "../helpers/choroplethHelpers";
 
 // TODO: this file has become very confusing and needs refactoring
 
@@ -16,24 +15,6 @@ export const renderMapViz = (map: mapboxgl.Map, data: VizData | undefined) => {
 
   const layer = layers.find((l) => l.name == data.geoType);
   const colours = getColours(data.params.mode, data.breaks);
-
-  // todo: understand this - should this be here?
-  //
-  if (data.params.mode === "change") {
-    // colour no-data areas to distinguish from neutral-change areas when doing change-over-time
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore (queryRenderedFeatures typings appear to be wrong)
-    const renderedGeos = map.queryRenderedFeatures({ layers: [`${data.geoType}-features`] }).map((g) => g.id);
-    const geosWithData = data.places.map((p) => p.geoCode);
-    renderedGeos.forEach((g) => {
-      if (!geosWithData.includes(g)) {
-        map.setFeatureState(
-          { source: layer.name, sourceLayer: layer.sourceLayer, id: g },
-          { colour: allColours.noData },
-        );
-      }
-    });
-  }
 
   data.places.forEach((p) => {
     map.setFeatureState(


### PR DESCRIPTION
- update choroplethHelpers.getChangeColours to use new 9-point colour scheme
- remove 'noData' colour and associated routine in renderMapViz - no data geos are now default grey in change
