### PR TITLE
Legend explanation improvements

### DIFF
--- a/src/components/MapLegend.svelte
+++ b/src/components/MapLegend.svelte
@@ -156,7 +156,11 @@
           classificationCode={$viz.params.classification.code}
           showPositive={shouldShowPositiveSign($viz.params.mode)}
         />
-        <MapLegendExplanation mode={$viz.params.mode} classificationCode={$viz.params.classification.code} />
+        <MapLegendExplanation
+          mode={$viz.params.mode}
+          classificationCode={$viz.params.classification.code}
+          variableName={$viz.params.variable.name}
+        />
       {/if}
     </div>
   </div>

--- a/src/components/MapLegendExplanation.svelte
+++ b/src/components/MapLegendExplanation.svelte
@@ -5,24 +5,22 @@
 
   export let mode: Mode;
   export let classificationCode: string;
+  export let variableName: string;
 </script>
 
 {#if mode === "change"}
   <div class="text-xs xs:text-sm pt-0.5 xs:pt-2.5">
     {#if classificationCode === "population_density"}
-      Percentage change in people per square kilometres between 2011 and 2021 census.
+      Percentage change in persons per square kilometre between 2011 and 2021 census.
     {:else if classificationCode === "median_age"}
       Change in median age between 2011 and 2021 census.
     {:else}
-      Change in
+      {variableName}: change in
       <a
         href="https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/populationestimates/articles/censusmaps/2022-11-02#:~:text=A%20percentage%20point%20change%20is%20the%20difference%20between%20percentages"
-        class="hyperlink-subdued mr-1">percentage points (pp)</a
-      ><span class="inline" aria-hidden="true">
-        <Icon kind="openInNew" />
-      </span>
-      for {$viz.params.variable.units}
-      between 2011 and 2021 census.
+        class="hyperlink-subdued">percentage points (pp)</a
+      >
+      for {$viz.params.variable.units} between 2011 and 2021 census.
     {/if}
   </div>
 {/if}

--- a/src/helpers/classificationHelpers.ts
+++ b/src/helpers/classificationHelpers.ts
@@ -19,7 +19,7 @@ const twoDecimalPlaceClassifications = [
 const classificationDataDisplayConfig = (classificationCode: string, mode: Mode) => {
   if (classificationCode === "population_density") {
     return {
-      suffix: mode === "change" ? " %" : "", // special-case for change-over-time
+      suffix: mode === "change" ? "%" : "", // special-case for change-over-time
       round: (r: number) => roundNumber({ number: r, decimalPlaces: mode === "change" ? 1 : 0 }),
       roundToString: (r: number) => (mode === "change" ? r.toFixed(1) : Math.round(r).toLocaleString()),
       roundBreaks: (breaks: number[]) =>


### PR DESCRIPTION
- for pop density, the small explanation said ‘people’ but the large unit has always said ‘persons’ - so change Percentage change in people per square kilometres between 2011 and 2021 census. to Percentage change in persons per square kilometre between 2011 and 2021 census. 
- add the variable name to the small explanation. I’ve finally found a way that I think works. This fixes lots of issues. I think it can probably be done without a re-QA because it’s only adding something that is already visible in the nav (namely, the variable name). 